### PR TITLE
feat: mirror workflow

### DIFF
--- a/.github/workflows/push_to_mirror.yaml
+++ b/.github/workflows/push_to_mirror.yaml
@@ -1,4 +1,4 @@
-## This is action will mirror the repository to the Epitech repository
+## This action mirrors the repository to the Epitech repository
 
 name: Mirror to Epitech
 

--- a/.github/workflows/push_to_mirror.yaml
+++ b/.github/workflows/push_to_mirror.yaml
@@ -1,0 +1,27 @@
+## This is action will mirror the repository to the Epitech repository
+
+name: Mirror to Epitech
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  TARGET_REPO_URL: "git@github.com:EpitechPromo2027/G-EIP-600-LYN-6-1-eip-sebastien.lucas.git"
+
+jobs:
+  to-tek-repo:
+    if: github.repository == 'scylla-ops/scylla'
+    runs-on: ubuntu-latest
+    name: Mirror to Epitech Job
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Push to mirror repository
+        uses: pixta-dev/repository-mirroring-action@v1
+        with:
+          target_repo_url: ${{ env.TARGET_REPO_URL }}
+          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate mirroring the repository to the Epitech repository. The workflow is triggered on pushes to the `main` branch and uses a repository mirroring action to sync changes.

### New GitHub Actions Workflow:
* [`.github/workflows/push_to_mirror.yaml`](diffhunk://#diff-5b347280d34fb8d16c157c45084230e979d172987e10e245d9d222c969b5e288R1-R27): Added a workflow named "Mirror to Epitech" that triggers on pushes to the `main` branch. It checks out the repository and mirrors it to a specified target repository (`EpitechPromo2027/G-EIP-600-LYN-6-1-eip-sebastien.lucas.git`) using the `pixta-dev/repository-mirroring-action`. The workflow is conditional on the repository being `scylla-ops/scylla`.