### PR TITLE
feat: implement permission service and gRPC handlers

### DIFF
--- a/apps/core/application/src/lib.rs
+++ b/apps/core/application/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod use_cases;
 
-pub use use_cases::{AuthUseCases, OrganizationUseCases, ProjectUseCases, UserUseCases};
+pub use use_cases::{
+    AuthUseCases, OrganizationUseCases, PermissionUseCases, ProjectUseCases, UserUseCases,
+};

--- a/apps/core/application/src/use_cases/mod.rs
+++ b/apps/core/application/src/use_cases/mod.rs
@@ -1,9 +1,11 @@
 pub mod auth;
 pub mod organization;
+pub mod permission;
 pub mod project;
 pub mod user;
 
 pub use auth::AuthUseCases;
 pub use organization::OrganizationUseCases;
+pub use permission::PermissionUseCases;
 pub use project::ProjectUseCases;
 pub use user::UserUseCases;

--- a/apps/core/application/src/use_cases/permission.rs
+++ b/apps/core/application/src/use_cases/permission.rs
@@ -1,0 +1,57 @@
+use derive_more::Constructor;
+use domain::entities::EntityId;
+use domain::errors::DomainResult;
+use domain::ports::services::permission_service::PermissionService;
+use domain::value_objects::permission::policy::{GroupingPolicy, Policy};
+use std::sync::Arc;
+
+#[derive(Constructor)]
+pub struct PermissionUseCases<PS: PermissionService> {
+    permission_service: Arc<PS>,
+}
+
+impl<PS: PermissionService> PermissionUseCases<PS> {
+    pub async fn add_policy(&self, sub: impl EntityId, policy: Policy) -> DomainResult<bool> {
+        self.permission_service.add_policy(sub, policy).await
+    }
+
+    pub async fn remove_policy(&self, sub: impl EntityId, policy: Policy) -> DomainResult<bool> {
+        self.permission_service.remove_policy(sub, policy).await
+    }
+
+    pub async fn list_policies(
+        &self,
+        subject: Option<&str>,
+    ) -> DomainResult<Vec<(String, Policy)>> {
+        self.permission_service.list_policies(subject).await
+    }
+
+    pub async fn add_grouping_policy(
+        &self,
+        sub: impl EntityId,
+        policy: GroupingPolicy,
+    ) -> DomainResult<bool> {
+        self.permission_service
+            .add_grouping_policy(sub, policy)
+            .await
+    }
+
+    pub async fn remove_grouping_policy(
+        &self,
+        sub: impl EntityId,
+        policy: GroupingPolicy,
+    ) -> DomainResult<bool> {
+        self.permission_service
+            .remove_grouping_policy(sub, policy)
+            .await
+    }
+
+    pub async fn list_grouping_policies(
+        &self,
+        subject: Option<&str>,
+    ) -> DomainResult<Vec<(String, GroupingPolicy)>> {
+        self.permission_service
+            .list_grouping_policies(subject)
+            .await
+    }
+}

--- a/apps/core/domain/src/ports/services/permission_service.rs
+++ b/apps/core/domain/src/ports/services/permission_service.rs
@@ -5,10 +5,25 @@ use crate::value_objects::permission::policy::{GroupingPolicy, Policy};
 #[async_trait::async_trait]
 pub trait PermissionService: Send + Sync {
     async fn check(&self, sub: impl EntityId, policy: Policy) -> DomainResult<bool>;
-    async fn add_policy(&mut self, sub: impl EntityId, policy: Policy) -> DomainResult<bool>;
+
+    async fn add_policy(&self, sub: impl EntityId, policy: Policy) -> DomainResult<bool>;
+    async fn remove_policy(&self, sub: impl EntityId, policy: Policy) -> DomainResult<bool>;
+    /// Returns all policy rows as (subject, Policy).
+    async fn list_policies(&self, subject: Option<&str>) -> DomainResult<Vec<(String, Policy)>>;
+
     async fn add_grouping_policy(
-        &mut self,
+        &self,
         sub: impl EntityId,
         policy: GroupingPolicy,
     ) -> DomainResult<bool>;
+    async fn remove_grouping_policy(
+        &self,
+        sub: impl EntityId,
+        policy: GroupingPolicy,
+    ) -> DomainResult<bool>;
+    /// Returns all grouping-policy rows as (subject, GroupingPolicy).
+    async fn list_grouping_policies(
+        &self,
+        subject: Option<&str>,
+    ) -> DomainResult<Vec<(String, GroupingPolicy)>>;
 }

--- a/apps/core/domain/src/value_objects/permission/act.rs
+++ b/apps/core/domain/src/value_objects/permission/act.rs
@@ -18,3 +18,17 @@ impl Act {
         }
     }
 }
+
+impl std::str::FromStr for Act {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "create" => Ok(Act::Create),
+            "read" => Ok(Act::Read),
+            "write" => Ok(Act::Write),
+            "delete" => Ok(Act::Delete),
+            _ => Ok(Act::All),
+        }
+    }
+}

--- a/apps/core/domain/src/value_objects/permission/policy.rs
+++ b/apps/core/domain/src/value_objects/permission/policy.rs
@@ -214,3 +214,17 @@ pub mod organization {
         )
     }
 }
+
+pub mod permission {
+    use super::*;
+
+    /// Any write operation on permissions requires absolute (super-admin) access.
+    pub fn manage() -> Policy {
+        Policy::absolute()
+    }
+
+    /// Listing permission rules requires system-level read-all.
+    pub fn list() -> Policy {
+        Policy::new(Scope::System, Resource::All, Act::Read)
+    }
+}

--- a/apps/core/domain/src/value_objects/permission/resource.rs
+++ b/apps/core/domain/src/value_objects/permission/resource.rs
@@ -30,3 +30,28 @@ impl Resource {
         }
     }
 }
+
+impl std::str::FromStr for Resource {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.split_once('/') {
+            None if s == "*" => Ok(Resource::All),
+            Some(("user", "*")) => Ok(Resource::User(Target::All)),
+            Some(("user", id)) => Ok(Resource::User(Target::Single(UserId::new(id.to_string())))),
+            Some(("project", "*")) => Ok(Resource::Project(Target::All)),
+            Some(("project", id)) => Ok(Resource::Project(Target::Single(ProjectId::new(
+                id.to_string(),
+            )))),
+            Some(("organization", "*")) => Ok(Resource::Organization(Target::All)),
+            Some(("organization", id)) => Ok(Resource::Organization(Target::Single(
+                OrganizationId::new(id.to_string()),
+            ))),
+            Some(("pipeline", "*")) => Ok(Resource::Pipeline(Target::All)),
+            Some(("pipeline", id)) => Ok(Resource::Pipeline(Target::Single(PipelineId::new(
+                id.to_string(),
+            )))),
+            _ => Err(()),
+        }
+    }
+}

--- a/apps/core/domain/src/value_objects/permission/scope.rs
+++ b/apps/core/domain/src/value_objects/permission/scope.rs
@@ -20,3 +20,18 @@ impl Scope {
         }
     }
 }
+
+impl std::str::FromStr for Scope {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.split_once('/') {
+            None if s == "system" => Ok(Scope::System),
+            None if s == "*" => Ok(Scope::All),
+            Some(("org", id)) => Ok(Scope::Org(OrganizationId::new(id.to_string()))),
+            Some(("project", id)) => Ok(Scope::Project(ProjectId::new(id.to_string()))),
+            Some(("user", id)) => Ok(Scope::User(UserId::new(id.to_string()))),
+            _ => Err(()),
+        }
+    }
+}

--- a/apps/core/infrastructure/src/services/casbin_permission_service.rs
+++ b/apps/core/infrastructure/src/services/casbin_permission_service.rs
@@ -1,14 +1,17 @@
-use casbin::{CoreApi, DefaultModel, Enforcer};
-use casbin::{MgmtApi, Result as CasbinResult};
+use casbin::Result as CasbinResult;
+use casbin::{CoreApi, DefaultModel, Enforcer, MgmtApi};
 use domain::entities::EntityId;
 use domain::errors::DomainResult;
 use domain::ports::services::permission_service::PermissionService;
 use domain::value_objects::permission::policy::{GroupingPolicy, Policy};
+use domain::value_objects::permission::{Act, Resource, Scope};
+use domain::value_objects::role::name::RoleName;
 use log::debug;
 use surreal_casbin_adapter::SurrealAdapter;
+use tokio::sync::RwLock;
 
 pub struct CasbinPermissionService {
-    enforcer: Enforcer,
+    enforcer: RwLock<Enforcer>,
 }
 
 const MODEL: &'static str = include_str!("../../../config/casbin/rbac_model.conf");
@@ -17,14 +20,17 @@ impl CasbinPermissionService {
     pub async fn new(adapter: SurrealAdapter) -> CasbinResult<Self> {
         let model = DefaultModel::from_str(MODEL).await?;
         let enforcer = Enforcer::new(model, adapter).await?;
-        Ok(Self { enforcer })
+        Ok(Self {
+            enforcer: RwLock::new(enforcer),
+        })
     }
 }
+
 #[async_trait::async_trait]
 impl PermissionService for CasbinPermissionService {
     async fn check(&self, sub: impl EntityId, policy: Policy) -> DomainResult<bool> {
-        let result = self
-            .enforcer
+        let enforcer = self.enforcer.read().await;
+        let result = enforcer
             .enforce((
                 sub.as_ref(),
                 policy.scope.as_str(),
@@ -43,8 +49,9 @@ impl PermissionService for CasbinPermissionService {
         }
     }
 
-    async fn add_policy(&mut self, sub: impl EntityId, policy: Policy) -> DomainResult<bool> {
-        self.enforcer
+    async fn add_policy(&self, sub: impl EntityId, policy: Policy) -> DomainResult<bool> {
+        let mut enforcer = self.enforcer.write().await;
+        enforcer
             .add_policy(vec![
                 sub.to_string(),
                 policy.scope.as_str(),
@@ -55,12 +62,52 @@ impl PermissionService for CasbinPermissionService {
             .map_err(|_| domain::errors::DomainError::Internal("Failed to add policy".to_string()))
     }
 
+    async fn remove_policy(&self, sub: impl EntityId, policy: Policy) -> DomainResult<bool> {
+        let mut enforcer = self.enforcer.write().await;
+        enforcer
+            .remove_policy(vec![
+                sub.to_string(),
+                policy.scope.as_str(),
+                policy.resource.as_str(),
+                policy.act.as_str().to_string(),
+            ])
+            .await
+            .map_err(|_| {
+                domain::errors::DomainError::Internal("Failed to remove policy".to_string())
+            })
+    }
+
+    async fn list_policies(&self, subject: Option<&str>) -> DomainResult<Vec<(String, Policy)>> {
+        let enforcer = self.enforcer.read().await;
+        let policies = enforcer.get_policy();
+        let result = policies
+            .into_iter()
+            .filter(|row| {
+                if let Some(sub) = subject {
+                    row.first().map(|s| s.as_str()) == Some(sub)
+                } else {
+                    true
+                }
+            })
+            .filter_map(|row| {
+                let get = |i: usize| row.get(i).cloned().unwrap_or_default();
+                let sub = get(0);
+                let scope: Scope = get(1).parse().ok()?;
+                let resource: Resource = get(2).parse().ok()?;
+                let act: Act = get(3).parse().ok()?;
+                Some((sub, Policy::new(scope, resource, act)))
+            })
+            .collect();
+        Ok(result)
+    }
+
     async fn add_grouping_policy(
-        &mut self,
+        &self,
         sub: impl EntityId,
         policy: GroupingPolicy,
     ) -> DomainResult<bool> {
-        self.enforcer
+        let mut enforcer = self.enforcer.write().await;
+        enforcer
             .add_grouping_policy(vec![
                 sub.to_string(),
                 policy.role.as_ref().to_string(),
@@ -70,5 +117,51 @@ impl PermissionService for CasbinPermissionService {
             .map_err(|_| {
                 domain::errors::DomainError::Internal("Failed to add grouping policy".to_string())
             })
+    }
+
+    async fn remove_grouping_policy(
+        &self,
+        sub: impl EntityId,
+        policy: GroupingPolicy,
+    ) -> DomainResult<bool> {
+        let mut enforcer = self.enforcer.write().await;
+        enforcer
+            .remove_grouping_policy(vec![
+                sub.to_string(),
+                policy.role.as_ref().to_string(),
+                policy.scope.as_str().to_string(),
+            ])
+            .await
+            .map_err(|_| {
+                domain::errors::DomainError::Internal(
+                    "Failed to remove grouping policy".to_string(),
+                )
+            })
+    }
+
+    async fn list_grouping_policies(
+        &self,
+        subject: Option<&str>,
+    ) -> DomainResult<Vec<(String, GroupingPolicy)>> {
+        let enforcer = self.enforcer.read().await;
+        let policies = enforcer.get_grouping_policy();
+        let result = policies
+            .into_iter()
+            .filter(|row| {
+                if let Some(sub) = subject {
+                    row.first().map(|s| s.as_str()) == Some(sub)
+                } else {
+                    true
+                }
+            })
+            .filter_map(|row| {
+                let get = |i: usize| row.get(i).cloned().unwrap_or_default();
+                let sub = get(0);
+                let role = RoleName::new(get(1)).ok()?;
+                let scope: Scope = get(2).parse().ok()?;
+                Some((sub, GroupingPolicy::new(role, scope)))
+            })
+            .collect();
+        Ok(result)
     }
 }

--- a/apps/core/interfaces/src/grpc/handlers/mod.rs
+++ b/apps/core/interfaces/src/grpc/handlers/mod.rs
@@ -3,10 +3,12 @@ pub mod macros;
 
 pub mod auth_handler;
 pub mod organization_handler;
+pub mod permission_handler;
 pub mod project_handler;
 pub mod user_handler;
 
 pub use auth_handler::AuthHandler;
 pub use organization_handler::OrganizationHandler;
+pub use permission_handler::PermissionHandler;
 pub use project_handler::ProjectHandler;
 pub use user_handler::UserHandler;

--- a/apps/core/interfaces/src/grpc/handlers/permission_handler.rs
+++ b/apps/core/interfaces/src/grpc/handlers/permission_handler.rs
@@ -1,0 +1,206 @@
+use crate::extract_auth_context;
+use crate::grpc::mappers::domain_error_to_status;
+use crate::grpc::mappers::permission_mapper::{
+    domain_act_to_proto, domain_resource_to_proto, domain_scope_to_proto, proto_act_to_domain,
+    proto_resource_to_domain, proto_scope_to_domain,
+};
+use application::PermissionUseCases;
+use derive_more::Constructor;
+use domain::entities::UserId;
+use domain::ports::services::permission_service::PermissionService;
+use domain::value_objects::permission::policy::{self, GroupingPolicy, Policy};
+use domain::value_objects::role::name::RoleName;
+use protocol::services::permission::{
+    Act as ProtoAct, AddGroupingPolicyRequest, AddGroupingPolicyResponse, AddPolicyRequest,
+    AddPolicyResponse, GroupingPolicyEntry, ListGroupingPoliciesRequest,
+    ListGroupingPoliciesResponse, ListPoliciesRequest, ListPoliciesResponse, PolicyEntry,
+    RemoveGroupingPolicyRequest, RemoveGroupingPolicyResponse, RemovePolicyRequest,
+    RemovePolicyResponse, permission_service_server::PermissionService as PermissionServiceTrait,
+};
+use std::sync::Arc;
+use tonic::{Request, Response, Status};
+
+#[derive(Constructor)]
+pub struct PermissionHandler<PS: PermissionService> {
+    use_cases: Arc<PermissionUseCases<PS>>,
+    permission_checker: Arc<PS>,
+}
+
+/// Build a domain `Policy` from strongly-typed proto values.
+fn proto_to_policy(
+    scope: protocol::services::permission::Scope,
+    resource: protocol::services::permission::Resource,
+    act_i32: i32,
+) -> Result<Policy, Status> {
+    let act = proto_act_to_domain(
+        ProtoAct::try_from(act_i32)
+            .map_err(|_| Status::invalid_argument(format!("Invalid act value: {}", act_i32)))?,
+    )
+    .map_err(domain_error_to_status)?;
+
+    let scope = proto_scope_to_domain(scope).map_err(domain_error_to_status)?;
+    let resource = proto_resource_to_domain(resource).map_err(domain_error_to_status)?;
+    Ok(Policy::new(scope, resource, act))
+}
+
+/// Convert a typed policy row to a proto `PolicyEntry`.
+fn row_to_policy_entry(subject: String, policy: Policy) -> PolicyEntry {
+    PolicyEntry {
+        subject,
+        scope: Some(domain_scope_to_proto(&policy.scope)),
+        resource: Some(domain_resource_to_proto(&policy.resource)),
+        act: domain_act_to_proto(&policy.act).into(),
+    }
+}
+
+/// Convert a typed grouping-policy row to a proto entry.
+fn row_to_grouping_entry(subject: String, policy: GroupingPolicy) -> GroupingPolicyEntry {
+    GroupingPolicyEntry {
+        subject,
+        role: policy.role.into_string(),
+        scope: Some(domain_scope_to_proto(&policy.scope)),
+    }
+}
+
+#[async_trait::async_trait]
+impl<PS: PermissionService + Send + Sync + 'static> PermissionServiceTrait
+    for PermissionHandler<PS>
+{
+    async fn add_policy(
+        &self,
+        request: Request<AddPolicyRequest>,
+    ) -> Result<Response<AddPolicyResponse>, Status> {
+        require_permission!(self, request, policy::permission::manage());
+        let req = request.into_inner();
+        let subject = UserId::new(req.subject);
+        let p = proto_to_policy(
+            req.scope
+                .ok_or_else(|| Status::invalid_argument("Missing scope"))?,
+            req.resource
+                .ok_or_else(|| Status::invalid_argument("Missing resource"))?,
+            req.act,
+        )?;
+
+        let added = self
+            .use_cases
+            .add_policy(subject, p)
+            .await
+            .map_err(domain_error_to_status)?;
+
+        Ok(Response::new(AddPolicyResponse { added }))
+    }
+
+    async fn remove_policy(
+        &self,
+        request: Request<RemovePolicyRequest>,
+    ) -> Result<Response<RemovePolicyResponse>, Status> {
+        require_permission!(self, request, policy::permission::manage());
+        let req = request.into_inner();
+        let subject = UserId::new(req.subject);
+        let p = proto_to_policy(
+            req.scope
+                .ok_or_else(|| Status::invalid_argument("Missing scope"))?,
+            req.resource
+                .ok_or_else(|| Status::invalid_argument("Missing resource"))?,
+            req.act,
+        )?;
+
+        let removed = self
+            .use_cases
+            .remove_policy(subject, p)
+            .await
+            .map_err(domain_error_to_status)?;
+
+        Ok(Response::new(RemovePolicyResponse { removed }))
+    }
+
+    async fn list_policies(
+        &self,
+        request: Request<ListPoliciesRequest>,
+    ) -> Result<Response<ListPoliciesResponse>, Status> {
+        require_permission!(self, request, policy::permission::list());
+        let req = request.into_inner();
+
+        let rows = self
+            .use_cases
+            .list_policies(req.subject.as_deref())
+            .await
+            .map_err(domain_error_to_status)?;
+
+        let policies = rows
+            .into_iter()
+            .map(|(sub, policy)| row_to_policy_entry(sub, policy))
+            .collect();
+
+        Ok(Response::new(ListPoliciesResponse { policies }))
+    }
+
+    async fn add_grouping_policy(
+        &self,
+        request: Request<AddGroupingPolicyRequest>,
+    ) -> Result<Response<AddGroupingPolicyResponse>, Status> {
+        require_permission!(self, request, policy::permission::manage());
+        let req = request.into_inner();
+        let subject = UserId::new(req.subject);
+        let scope_proto = req
+            .scope
+            .ok_or_else(|| Status::invalid_argument("Missing scope"))?;
+        let scope = proto_scope_to_domain(scope_proto).map_err(domain_error_to_status)?;
+        let role = RoleName::new(req.role).map_err(domain_error_to_status)?;
+        let gp = GroupingPolicy::new(role, scope);
+
+        let added = self
+            .use_cases
+            .add_grouping_policy(subject, gp)
+            .await
+            .map_err(domain_error_to_status)?;
+
+        Ok(Response::new(AddGroupingPolicyResponse { added }))
+    }
+
+    async fn remove_grouping_policy(
+        &self,
+        request: Request<RemoveGroupingPolicyRequest>,
+    ) -> Result<Response<RemoveGroupingPolicyResponse>, Status> {
+        require_permission!(self, request, policy::permission::manage());
+        let req = request.into_inner();
+        let subject = UserId::new(req.subject);
+        let scope_proto = req
+            .scope
+            .ok_or_else(|| Status::invalid_argument("Missing scope"))?;
+        let scope = proto_scope_to_domain(scope_proto).map_err(domain_error_to_status)?;
+        let role = RoleName::new(req.role).map_err(domain_error_to_status)?;
+        let gp = GroupingPolicy::new(role, scope);
+
+        let removed = self
+            .use_cases
+            .remove_grouping_policy(subject, gp)
+            .await
+            .map_err(domain_error_to_status)?;
+
+        Ok(Response::new(RemoveGroupingPolicyResponse { removed }))
+    }
+
+    async fn list_grouping_policies(
+        &self,
+        request: Request<ListGroupingPoliciesRequest>,
+    ) -> Result<Response<ListGroupingPoliciesResponse>, Status> {
+        require_permission!(self, request, policy::permission::list());
+        let req = request.into_inner();
+
+        let rows = self
+            .use_cases
+            .list_grouping_policies(req.subject.as_deref())
+            .await
+            .map_err(domain_error_to_status)?;
+
+        let grouping_policies = rows
+            .into_iter()
+            .map(|(sub, policy)| row_to_grouping_entry(sub, policy))
+            .collect();
+
+        Ok(Response::new(ListGroupingPoliciesResponse {
+            grouping_policies,
+        }))
+    }
+}

--- a/apps/core/interfaces/src/grpc/mappers/mod.rs
+++ b/apps/core/interfaces/src/grpc/mappers/mod.rs
@@ -1,6 +1,7 @@
 pub mod error_mapper;
 pub mod organization_mapper;
 pub mod pagination_mapper;
+pub mod permission_mapper;
 pub mod project_mapper;
 pub mod user_mapper;
 

--- a/apps/core/interfaces/src/grpc/mappers/permission_mapper.rs
+++ b/apps/core/interfaces/src/grpc/mappers/permission_mapper.rs
@@ -1,0 +1,153 @@
+use domain::entities::{OrganizationId, PipelineId, ProjectId, UserId};
+use domain::errors::{DomainError, DomainResult};
+use domain::value_objects::permission::{Act, Resource, Scope, Target};
+use protocol::services::permission::{
+    Act as ProtoAct, Resource as ProtoResource, ResourceType, Scope as ProtoScope, ScopeType,
+};
+
+// ── Act ───────────────────────────────────────────────────────────────────────
+
+pub fn proto_act_to_domain(proto: ProtoAct) -> DomainResult<Act> {
+    match proto {
+        ProtoAct::Create => Ok(Act::Create),
+        ProtoAct::Read => Ok(Act::Read),
+        ProtoAct::Write => Ok(Act::Write),
+        ProtoAct::Delete => Ok(Act::Delete),
+        ProtoAct::All => Ok(Act::All),
+    }
+}
+
+pub fn domain_act_to_proto(act: &Act) -> ProtoAct {
+    match act {
+        Act::Create => ProtoAct::Create,
+        Act::Read => ProtoAct::Read,
+        Act::Write => ProtoAct::Write,
+        Act::Delete => ProtoAct::Delete,
+        Act::All => ProtoAct::All,
+    }
+}
+
+// ── Scope ─────────────────────────────────────────────────────────────────────
+
+pub fn proto_scope_to_domain(proto: ProtoScope) -> DomainResult<Scope> {
+    let scope_type = ScopeType::try_from(proto.r#type).map_err(|_| {
+        DomainError::Validation(format!("Invalid ScopeType value: {}", proto.r#type))
+    })?;
+
+    match scope_type {
+        ScopeType::ScopeSystem => Ok(Scope::System),
+        ScopeType::ScopeAll => Ok(Scope::All),
+        ScopeType::ScopeOrg => {
+            let id = proto.id.ok_or_else(|| {
+                DomainError::Validation("ScopeOrg requires an organization id".to_string())
+            })?;
+            Ok(Scope::Org(OrganizationId::new(id)))
+        }
+        ScopeType::ScopeProject => {
+            let id = proto.id.ok_or_else(|| {
+                DomainError::Validation("ScopeProject requires a project id".to_string())
+            })?;
+            Ok(Scope::Project(ProjectId::new(id)))
+        }
+        ScopeType::ScopeUser => {
+            let id = proto.id.ok_or_else(|| {
+                DomainError::Validation("ScopeUser requires a user id".to_string())
+            })?;
+            Ok(Scope::User(UserId::new(id)))
+        }
+    }
+}
+
+pub fn domain_scope_to_proto(scope: &Scope) -> ProtoScope {
+    match scope {
+        Scope::System => ProtoScope {
+            r#type: ScopeType::ScopeSystem.into(),
+            id: None,
+        },
+        Scope::All => ProtoScope {
+            r#type: ScopeType::ScopeAll.into(),
+            id: None,
+        },
+        Scope::Org(id) => ProtoScope {
+            r#type: ScopeType::ScopeOrg.into(),
+            id: Some(id.to_string()),
+        },
+        Scope::Project(id) => ProtoScope {
+            r#type: ScopeType::ScopeProject.into(),
+            id: Some(id.to_string()),
+        },
+        Scope::User(id) => ProtoScope {
+            r#type: ScopeType::ScopeUser.into(),
+            id: Some(id.to_string()),
+        },
+    }
+}
+
+// ── Resource ─────────────────────────────────────────────────────────────────
+
+pub fn proto_resource_to_domain(proto: ProtoResource) -> DomainResult<Resource> {
+    let resource_type = ResourceType::try_from(proto.r#type).map_err(|_| {
+        DomainError::Validation(format!("Invalid ResourceType value: {}", proto.r#type))
+    })?;
+
+    match (resource_type, proto.id) {
+        (ResourceType::ResourceUser, None) => Ok(Resource::User(Target::All)),
+        (ResourceType::ResourceUser, Some(id)) => {
+            Ok(Resource::User(Target::Single(UserId::new(id))))
+        }
+        (ResourceType::ResourceProject, None) => Ok(Resource::Project(Target::All)),
+        (ResourceType::ResourceProject, Some(id)) => {
+            Ok(Resource::Project(Target::Single(ProjectId::new(id))))
+        }
+        (ResourceType::ResourceOrganization, None) => Ok(Resource::Organization(Target::All)),
+        (ResourceType::ResourceOrganization, Some(id)) => Ok(Resource::Organization(
+            Target::Single(OrganizationId::new(id)),
+        )),
+        (ResourceType::ResourcePipeline, None) => Ok(Resource::Pipeline(Target::All)),
+        (ResourceType::ResourcePipeline, Some(id)) => {
+            Ok(Resource::Pipeline(Target::Single(PipelineId::new(id))))
+        }
+        (ResourceType::ResourceAll, _) => Ok(Resource::All),
+    }
+}
+
+pub fn domain_resource_to_proto(resource: &Resource) -> ProtoResource {
+    match resource {
+        Resource::All => ProtoResource {
+            r#type: ResourceType::ResourceAll.into(),
+            id: None,
+        },
+        Resource::User(Target::All) => ProtoResource {
+            r#type: ResourceType::ResourceUser.into(),
+            id: None,
+        },
+        Resource::User(Target::Single(id)) => ProtoResource {
+            r#type: ResourceType::ResourceUser.into(),
+            id: Some(id.to_string()),
+        },
+        Resource::Project(Target::All) => ProtoResource {
+            r#type: ResourceType::ResourceProject.into(),
+            id: None,
+        },
+        Resource::Project(Target::Single(id)) => ProtoResource {
+            r#type: ResourceType::ResourceProject.into(),
+            id: Some(id.to_string()),
+        },
+        Resource::Organization(Target::All) => ProtoResource {
+            r#type: ResourceType::ResourceOrganization.into(),
+            id: None,
+        },
+        Resource::Organization(Target::Single(id)) => ProtoResource {
+            r#type: ResourceType::ResourceOrganization.into(),
+            id: Some(id.to_string()),
+        },
+        Resource::Pipeline(Target::All) => ProtoResource {
+            r#type: ResourceType::ResourcePipeline.into(),
+            id: None,
+        },
+        Resource::Pipeline(Target::Single(id)) => ProtoResource {
+            r#type: ResourceType::ResourcePipeline.into(),
+            id: Some(id.to_string()),
+        },
+    }
+}

--- a/apps/core/interfaces/src/grpc/mod.rs
+++ b/apps/core/interfaces/src/grpc/mod.rs
@@ -2,7 +2,9 @@ mod handlers;
 pub mod mappers;
 pub mod middleware;
 
-pub use handlers::{AuthHandler, OrganizationHandler, ProjectHandler, UserHandler};
+pub use handlers::{
+    AuthHandler, OrganizationHandler, PermissionHandler, ProjectHandler, UserHandler,
+};
 pub use mappers::{
     domain_error_to_status, domain_to_proto_metadata, organization_to_proto, project_to_proto,
     proto_to_domain_pagination, user_to_proto,

--- a/apps/core/interfaces/src/lib.rs
+++ b/apps/core/interfaces/src/lib.rs
@@ -1,7 +1,8 @@
 pub mod grpc;
 
 pub use grpc::{
-    AuthContext, AuthHandler, OrganizationHandler, ProjectHandler, UserHandler, auth_interceptor,
-    domain_error_to_status, domain_to_proto_metadata, middleware::extract_auth_context,
-    organization_to_proto, project_to_proto, proto_to_domain_pagination, user_to_proto,
+    AuthContext, AuthHandler, OrganizationHandler, PermissionHandler, ProjectHandler, UserHandler,
+    auth_interceptor, domain_error_to_status, domain_to_proto_metadata,
+    middleware::extract_auth_context, organization_to_proto, project_to_proto,
+    proto_to_domain_pagination, user_to_proto,
 };

--- a/apps/core/src/main.rs
+++ b/apps/core/src/main.rs
@@ -1,16 +1,21 @@
 mod config;
 
-use application::{AuthUseCases, OrganizationUseCases, ProjectUseCases, UserUseCases};
+use application::{
+    AuthUseCases, OrganizationUseCases, PermissionUseCases, ProjectUseCases, UserUseCases,
+};
 use config::{BootstrapConfig, CoreConfig};
 use infrastructure::{
     Argon2HashService, SurrealOrganizationRepository, SurrealProjectRepository,
     SurrealSessionRepository, SurrealUserOrganizationRepository, SurrealUserProjectRepository,
     SurrealUserRepository,
 };
-use interfaces::{AuthHandler, OrganizationHandler, ProjectHandler, UserHandler};
+use interfaces::{
+    AuthHandler, OrganizationHandler, PermissionHandler, ProjectHandler, UserHandler,
+};
 use protocol::services::{
     auth::auth_service_server::AuthServiceServer,
     organization::organization_service_server::OrganizationServiceServer,
+    permission::permission_service_server::PermissionServiceServer,
     project::project_service_server::ProjectServiceServer,
     user::user_service_server::UserServiceServer,
 };
@@ -233,10 +238,13 @@ async fn run(args: Args) -> Result<()> {
 
     let permission_checker = Arc::new(casbin_service);
 
+    let permission_uc = Arc::new(PermissionUseCases::new(permission_checker.clone()));
+
     let auth_handler = AuthHandler::new(auth_uc);
     let user_handler = UserHandler::new(user_uc, permission_checker.clone());
     let org_handler = OrganizationHandler::new(org_uc, permission_checker.clone());
     let project_handler = ProjectHandler::new(project_uc, permission_checker.clone());
+    let permission_handler = PermissionHandler::new(permission_uc, permission_checker.clone());
 
     let auth_interceptor = async_interceptor(AuthInterceptor::new(session_repo.clone()));
     let cors_layer = build_cors_layer(&config.cors);
@@ -258,8 +266,12 @@ async fn run(args: Args) -> Result<()> {
         .service(OrganizationServiceServer::new(org_handler));
 
     let project_service = ServiceBuilder::new()
-        .layer(auth_interceptor)
+        .layer(auth_interceptor.clone())
         .service(ProjectServiceServer::new(project_handler));
+
+    let permission_service = ServiceBuilder::new()
+        .layer(auth_interceptor)
+        .service(PermissionServiceServer::new(permission_handler));
 
     Server::builder()
         .accept_http1(true)
@@ -271,6 +283,7 @@ async fn run(args: Args) -> Result<()> {
         .add_service(user_service)
         .add_service(org_service)
         .add_service(project_service)
+        .add_service(permission_service)
         .serve(config.grpc.address)
         .await?;
 

--- a/libs/protocol/build.rs
+++ b/libs/protocol/build.rs
@@ -16,6 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "job_def.proto",
         "organization.proto",
         "project.proto",
+        "permission.proto",
     ]
     .map(|f| proto_dir.join(f));
 

--- a/libs/protocol/proto/permission.proto
+++ b/libs/protocol/proto/permission.proto
@@ -1,0 +1,119 @@
+syntax = "proto3";
+
+package permission;
+
+// ── Shared typed enums ───────────────────────────────────────────────────────
+
+enum Act {
+  ACT_CREATE      = 0;
+  ACT_READ        = 1;
+  ACT_WRITE       = 2;
+  ACT_DELETE      = 3;
+  ACT_ALL         = 4;
+}
+
+enum ScopeType {
+  SCOPE_SYSTEM    = 0;
+  SCOPE_ORG       = 1; // id required
+  SCOPE_PROJECT   = 2; // id required
+  SCOPE_USER      = 3; // id required
+  SCOPE_ALL       = 4;
+}
+
+// A scope is a type (system-wide, org, project, user) plus an optional id.
+message Scope {
+  ScopeType type    = 1;
+  optional string id = 2;
+}
+
+enum ResourceType {
+  RESOURCE_USER         = 0;
+  RESOURCE_PROJECT      = 1;
+  RESOURCE_ORGANIZATION = 2;
+  RESOURCE_PIPELINE     = 3;
+  RESOURCE_ALL          = 4;
+}
+
+// A resource is a type plus an optional id.
+// Absence of id means Target::All (wildcard).
+message Resource {
+  ResourceType type  = 1;
+  optional string id = 2;
+}
+
+// ── Service ──────────────────────────────────────────────────────────────────
+
+service PermissionService {
+  rpc AddPolicy(AddPolicyRequest)                         returns (AddPolicyResponse);
+  rpc RemovePolicy(RemovePolicyRequest)                   returns (RemovePolicyResponse);
+  rpc ListPolicies(ListPoliciesRequest)                   returns (ListPoliciesResponse);
+
+  rpc AddGroupingPolicy(AddGroupingPolicyRequest)         returns (AddGroupingPolicyResponse);
+  rpc RemoveGroupingPolicy(RemoveGroupingPolicyRequest)   returns (RemoveGroupingPolicyResponse);
+  rpc ListGroupingPolicies(ListGroupingPoliciesRequest)   returns (ListGroupingPoliciesResponse);
+}
+
+// ── Policy RPCs ──────────────────────────────────────────────────────────────
+
+message PolicyEntry {
+  string   subject  = 1;
+  Scope    scope    = 2;
+  Resource resource = 3;
+  Act      act      = 4;
+}
+
+message AddPolicyRequest {
+  string   subject  = 1;
+  Scope    scope    = 2;
+  Resource resource = 3;
+  Act      act      = 4;
+}
+
+message AddPolicyResponse { bool added = 1; }
+
+message RemovePolicyRequest {
+  string   subject  = 1;
+  Scope    scope    = 2;
+  Resource resource = 3;
+  Act      act      = 4;
+}
+
+message RemovePolicyResponse { bool removed = 1; }
+
+message ListPoliciesRequest {
+  optional string subject = 1;
+}
+
+message ListPoliciesResponse { repeated PolicyEntry policies = 1; }
+
+// ── Grouping policy RPCs ─────────────────────────────────────────────────────
+
+message GroupingPolicyEntry {
+  string subject = 1;
+  string role    = 2;
+  Scope  scope   = 3;
+}
+
+message AddGroupingPolicyRequest {
+  string subject = 1;
+  string role    = 2;
+  Scope  scope   = 3;
+}
+
+message AddGroupingPolicyResponse { bool added = 1; }
+
+message RemoveGroupingPolicyRequest {
+  string subject = 1;
+  string role    = 2;
+  Scope  scope   = 3;
+}
+
+message RemoveGroupingPolicyResponse { bool removed = 1; }
+
+message ListGroupingPoliciesRequest {
+  optional string subject = 1;
+}
+
+message ListGroupingPoliciesResponse {
+  repeated GroupingPolicyEntry grouping_policies = 1;
+}

--- a/libs/protocol/src/lib.rs
+++ b/libs/protocol/src/lib.rs
@@ -29,6 +29,9 @@ pub mod services {
     pub mod job_def {
         tonic::include_proto!("job_def");
     }
+    pub mod permission {
+        tonic::include_proto!("permission");
+    }
 
     pub const FILE_DESCRIPTOR_SET: &[u8] =
         tonic::include_file_descriptor_set!("services_descriptor");


### PR DESCRIPTION
This pull request introduces a comprehensive permissions management system to the core application, including new domain logic, infrastructure, and gRPC interfaces. The main themes are: adding permission use cases, extending the domain model for permissions, updating the infrastructure to support concurrent access, and exposing new gRPC handlers for permissions.

**Permissions Management Features**

* Added `PermissionUseCases` to the application layer, providing methods for adding, removing, and listing both policies and grouping policies. (`apps/core/application/src/use_cases/permission.rs`)
* Introduced a new gRPC handler `PermissionHandler` with endpoints for managing policies and grouping policies, including permission checks and mapping between domain and proto types. (`apps/core/interfaces/src/grpc/handlers/permission_handler.rs`)

**Domain Model Extensions**

* Extended the `PermissionService` trait with new async methods for removing and listing policies/grouping policies, and changed mutability requirements to allow concurrent access. (`apps/core/domain/src/ports/services/permission_service.rs`)
* Added `FromStr` implementations for `Act`, `Resource`, and `Scope` to support parsing from strings, improving flexibility in policy handling. (`apps/core/domain/src/value_objects/permission/act.rs`, `resource.rs`, `scope.rs`) [[1]](diffhunk://#diff-04c2ac53759ed713de3b4270d4f01ed447d077669a0e6018a15469d19d0a7d2aR21-R34) [[2]](diffhunk://#diff-87e4e2e433bfdd0160386f660d7775da31cc536357493af09fdd27dbce9e6493R33-R57) [[3]](diffhunk://#diff-1966f132e7ab9fe0a602dfbd4bbb3a8801578d78aadee4e83c916e94b5abbbd0R23-R37)
* Added helper functions for permission management and listing to the domain policy module. (`apps/core/domain/src/value_objects/permission/policy.rs`)

**Infrastructure Updates**

* Updated `CasbinPermissionService` to use a `RwLock` for the enforcer, enabling safe concurrent reads/writes, and implemented the new PermissionService methods for policy and grouping policy management. (`apps/core/infrastructure/src/services/casbin_permission_service.rs`) [[1]](diffhunk://#diff-65274efe997d76626e1c54f14b6710b5040e3ffabc432bfe4ea99e06234bc100L1-R14) [[2]](diffhunk://#diff-65274efe997d76626e1c54f14b6710b5040e3ffabc432bfe4ea99e06234bc100L20-R33) [[3]](diffhunk://#diff-65274efe997d76626e1c54f14b6710b5040e3ffabc432bfe4ea99e06234bc100L46-R54) [[4]](diffhunk://#diff-65274efe997d76626e1c54f14b6710b5040e3ffabc432bfe4ea99e06234bc100R65-R110) [[5]](diffhunk://#diff-65274efe997d76626e1c54f14b6710b5040e3ffabc432bfe4ea99e06234bc100R121-R166)

**gRPC and Application Integration**

* Registered the new permission handler and mappers in the gRPC module, and updated exports to include permission-related types. (`apps/core/interfaces/src/grpc/handlers/mod.rs`, `apps/core/interfaces/src/grpc/mappers/mod.rs`, `apps/core/application/src/lib.rs`, `apps/core/application/src/use_cases/mod.rs`) [[1]](diffhunk://#diff-625b7c118651992df4a76912a04b8199a46c0ff543111b193f30e6c5ecaa97ddR6-R12) [[2]](diffhunk://#diff-1aa4931bbfb3a025b7d3568a5cc258d5975b59625ed7be699ba4784fa2e90aa7R4) [[3]](diffhunk://#diff-2ba747a44d5a2dfb4e01b8bb5eb72eea70e8d531ece153aaf5b9deeded14a76aL3-R5) [[4]](diffhunk://#diff-19187f7da6510c567784858ad2120e2f1d62df182d7aa8e9cbabb43f28fbc3e3R3-R9)