### PR TITLE
test: add empty-list tests + fix clippy warnings 

### DIFF
--- a/.claude/skills/commit-message/SKILL.md
+++ b/.claude/skills/commit-message/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: commit-message
+description: Write a clear and concise Git commit message summarizing the changes. Use when committing anything
+---
+
+Write a commit message for the staged changes. Only output the message, no commentary.
+
+Rules:
+- Conventional commit style, imperative mood, subject and body all lowercase, no trailing punctuation
+- Subject line ≤50 chars; omit body unless it adds info not in the subject
+- No bullet points, no repeating the subject in the body, no raw diffs

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: review-pr
+description: Review a pull request or set of changes for bugs, style issues, and improvements. Use when the user asks to review code or a PR.
+---
+
+Review the given PR or diff. Focus on:
+- Correctness: bugs, logic errors, edge cases, security issues
+- Style: naming, consistency with surrounding code, readability
+- Design: unnecessary complexity, missing abstractions, or over-engineering
+
+Be direct and specific. Reference file paths and line numbers. Skip praise for things that are simply correct. Only flag real issues or meaningful suggestions. Group feedback by severity (must-fix vs nice-to-have).
+
+If given a PR number, fetch it with `gh pr diff <number>`. If no number given, review the current branch's diff against the base branch.

--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: write-tests
+description: Generate tests for a function, module, or file. Use when the user asks to add or write tests.
+---
+
+Write tests for the specified code. Before writing:
+1. Read the target code and any existing test files to match the project's test framework, style, and conventions
+2. Identify the test framework in use (check package.json, pyproject.toml, Cargo.toml, etc.)
+
+Cover: happy path, edge cases, error conditions. Keep tests focused — one assertion per behavior. Use descriptive test names that explain the expected behavior. Don't mock what you don't need to.

--- a/apps/core/infrastructure/src/persistence/surrealdb/job_repository.rs
+++ b/apps/core/infrastructure/src/persistence/surrealdb/job_repository.rs
@@ -205,7 +205,12 @@ mod tests {
     use domain::value_objects::pipeline::{NodeId, PipelineName};
 
     async fn setup() -> Surreal<Any> {
-        init_db(&[JobId::table_name()]).await
+        init_db(&[
+            JobId::table_name(),
+            PipelineId::table_name(),
+            ProjectId::table_name(),
+        ])
+        .await
     }
 
     fn node(id: &str, deps: &[&str]) -> PipelineNode {
@@ -341,5 +346,71 @@ mod tests {
 
         assert_eq!(result.items().len(), 1);
         assert_eq!(result.items()[0].pipeline_id(), pipeline_a.id());
+    }
+
+    #[tokio::test]
+    async fn test_list_all_empty() {
+        let db = setup().await;
+        let repo = SurrealJobRepository::new(db);
+
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo.list_all(Some(&pagination)).await.unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_all_default_pagination() {
+        let db = setup().await;
+        let repo = SurrealJobRepository::new(db);
+
+        let result = repo.list_all(None).await.unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_by_pipeline_empty() {
+        let db = setup().await;
+        let repo = SurrealJobRepository::new(db);
+
+        let pipeline_id = PipelineId::generate();
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo
+            .list_by_pipeline(&pipeline_id, Some(&pagination))
+            .await
+            .unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_by_project_empty() {
+        let db = setup().await;
+        let repo = SurrealJobRepository::new(db);
+
+        let project_id = ProjectId::generate();
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo
+            .list_by_project(&project_id, Some(&pagination))
+            .await
+            .unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_by_organization_empty() {
+        let db = setup().await;
+        let repo = SurrealJobRepository::new(db);
+
+        let org_id = OrganizationId::generate();
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo
+            .list_by_organization(&org_id, Some(&pagination))
+            .await
+            .unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
     }
 }

--- a/apps/core/infrastructure/src/persistence/surrealdb/organization_repository.rs
+++ b/apps/core/infrastructure/src/persistence/surrealdb/organization_repository.rs
@@ -337,6 +337,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_list_all_empty() {
+        let db = setup().await;
+        let repo = SurrealOrganizationRepository::new(db);
+
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo.list_all(Some(&pagination)).await.unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_active_empty() {
+        let db = setup().await;
+        let repo = SurrealOrganizationRepository::new(db);
+
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo.list_active(Some(&pagination)).await.unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
     async fn test_list_active() {
         let db = setup().await;
         let repo = SurrealOrganizationRepository::new(db);

--- a/apps/core/infrastructure/src/persistence/surrealdb/pipeline_repository.rs
+++ b/apps/core/infrastructure/src/persistence/surrealdb/pipeline_repository.rs
@@ -176,12 +176,12 @@ impl PipelineRepository for SurrealPipelineRepository {
 mod tests {
     use super::*;
     use crate::test_utils::init_db;
-    use domain::entities::{PipelineNode, ProjectId};
+    use domain::entities::{OrganizationId, PipelineNode, ProjectId};
     use domain::value_objects::PaginationParams;
     use domain::value_objects::pipeline::{NodeId, PipelineName};
 
     async fn setup() -> Surreal<Any> {
-        init_db(&[PipelineId::table_name()]).await
+        init_db(&[PipelineId::table_name(), ProjectId::table_name()]).await
     }
 
     fn test_project_id() -> ProjectId {
@@ -319,5 +319,56 @@ mod tests {
 
         assert_eq!(result.items().len(), 1);
         assert_eq!(result.items()[0].project_id(), &project_a);
+    }
+
+    #[tokio::test]
+    async fn test_list_all_empty() {
+        let db = setup().await;
+        let repo = SurrealPipelineRepository::new(db);
+
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo.list_all(Some(&pagination)).await.unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_all_default_pagination() {
+        let db = setup().await;
+        let repo = SurrealPipelineRepository::new(db);
+
+        let result = repo.list_all(None).await.unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_by_project_empty() {
+        let db = setup().await;
+        let repo = SurrealPipelineRepository::new(db);
+
+        let project_id = test_project_id();
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo
+            .list_by_project(&project_id, Some(&pagination))
+            .await
+            .unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_by_organization_empty() {
+        let db = setup().await;
+        let repo = SurrealPipelineRepository::new(db);
+
+        let org_id = OrganizationId::generate();
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo
+            .list_by_organization(&org_id, Some(&pagination))
+            .await
+            .unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
     }
 }

--- a/apps/core/infrastructure/src/persistence/surrealdb/project_repository.rs
+++ b/apps/core/infrastructure/src/persistence/surrealdb/project_repository.rs
@@ -287,6 +287,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_list_all_empty() {
+        let db = setup().await;
+        let repo = SurrealProjectRepository::new(db);
+
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo.list_all(Some(&pagination)).await.unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_active_empty() {
+        let db = setup().await;
+        let repo = SurrealProjectRepository::new(db);
+
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo.list_active(Some(&pagination)).await.unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
     async fn test_list_active() {
         let db = setup().await;
         let repo = SurrealProjectRepository::new(db);

--- a/apps/core/infrastructure/src/persistence/surrealdb/user_organization_repository.rs
+++ b/apps/core/infrastructure/src/persistence/surrealdb/user_organization_repository.rs
@@ -215,6 +215,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_list_members_empty() {
+        let db = setup().await;
+        let repo = SurrealUserOrganizationRepository::new(db);
+
+        let org_id = test_org_id();
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo
+            .list_members(&org_id, Some(&pagination))
+            .await
+            .unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_user_organizations_empty() {
+        let db = setup().await;
+        let repo = SurrealUserOrganizationRepository::new(db);
+
+        let user_id = test_user_id();
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo
+            .list_user_organizations(&user_id, Some(&pagination))
+            .await
+            .unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
     async fn test_list_members() {
         let db = setup().await;
         let repo = SurrealUserOrganizationRepository::new(db);

--- a/apps/core/infrastructure/src/persistence/surrealdb/user_project_repository.rs
+++ b/apps/core/infrastructure/src/persistence/surrealdb/user_project_repository.rs
@@ -219,6 +219,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_list_members_empty() {
+        let db = setup().await;
+        let repo = SurrealUserProjectRepository::new(db);
+
+        let project_id = test_project_id();
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo
+            .list_members(&project_id, Some(&pagination))
+            .await
+            .unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_user_projects_empty() {
+        let db = setup().await;
+        let repo = SurrealUserProjectRepository::new(db);
+
+        let user_id = test_user_id();
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo
+            .list_user_projects(&user_id, Some(&pagination))
+            .await
+            .unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
     async fn test_list_members() {
         let db = setup().await;
         let repo = SurrealUserProjectRepository::new(db);

--- a/apps/core/infrastructure/src/persistence/surrealdb/user_repository.rs
+++ b/apps/core/infrastructure/src/persistence/surrealdb/user_repository.rs
@@ -312,6 +312,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_list_all_empty() {
+        let db = setup().await;
+        let repo = SurrealUserRepository::new(db);
+
+        let pagination = PaginationParams::new(1, 20).unwrap();
+        let result = repo.list_all(Some(&pagination)).await.unwrap();
+        assert_eq!(result.items().len(), 0);
+        assert_eq!(result.metadata().total_count(), 0);
+    }
+
+    #[tokio::test]
     async fn test_username_exists() {
         let db = setup().await;
         let repo = SurrealUserRepository::new(db);

--- a/apps/core/infrastructure/src/services/casbin_permission_service.rs
+++ b/apps/core/infrastructure/src/services/casbin_permission_service.rs
@@ -14,7 +14,7 @@ pub struct CasbinPermissionService {
     enforcer: RwLock<Enforcer>,
 }
 
-const MODEL: &'static str = include_str!("../../../config/casbin/rbac_model.conf");
+const MODEL: &str = include_str!("../../../config/casbin/rbac_model.conf");
 
 impl CasbinPermissionService {
     pub async fn new(adapter: SurrealAdapter) -> CasbinResult<Self> {

--- a/apps/core/interfaces/src/grpc/handlers/organization_handler.rs
+++ b/apps/core/interfaces/src/grpc/handlers/organization_handler.rs
@@ -213,7 +213,7 @@ impl<
             request,
             policy::organization::list_user_orgs(user_id.clone())
         );
-        let pagination = proto_to_domain_pagination(request.get_ref().pagination.clone());
+        let pagination = proto_to_domain_pagination(request.get_ref().pagination);
 
         let (orgs, metadata) = self
             .use_cases

--- a/apps/core/interfaces/src/grpc/mappers/pipeline_mapper.rs
+++ b/apps/core/interfaces/src/grpc/mappers/pipeline_mapper.rs
@@ -21,6 +21,6 @@ pub fn pipeline_node_to_proto(node: &domain::entities::PipelineNode) -> Pipeline
         node_id: node.id().to_string(),
         deps: node.deps().iter().map(|d| d.to_string()).collect(),
         command: node.command().to_string(),
-        args: node.args().iter().cloned().collect(),
+        args: node.args().to_vec(),
     }
 }

--- a/apps/core/interfaces/src/grpc/middleware/auth_interceptor.rs
+++ b/apps/core/interfaces/src/grpc/middleware/auth_interceptor.rs
@@ -19,7 +19,7 @@ pub fn extract_auth_context<T>(request: &Request<T>) -> Result<AuthContext, Stat
         .ok_or_else(|| {
             Status::internal("Auth context not found — interceptor may not be configured")
         })
-        .map(|ctx| ctx.clone())
+        .cloned()
 }
 
 fn extract_bearer_token<T>(request: &Request<T>) -> Result<String, Status> {

--- a/apps/core/src/config.rs
+++ b/apps/core/src/config.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::net::SocketAddr;
 use std::path::Path;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct CoreConfig {
     #[serde(default)]
     pub grpc: GrpcConfig,
@@ -102,16 +102,6 @@ fn default_max_age() -> u64 {
     600
 }
 
-impl Default for CoreConfig {
-    fn default() -> Self {
-        Self {
-            grpc: GrpcConfig::default(),
-            database: DatabaseConfig::default(),
-            cors: CorsConfig::default(),
-            bootstrap: None,
-        }
-    }
-}
 
 impl Default for GrpcConfig {
     fn default() -> Self {

--- a/apps/core/src/db.rs
+++ b/apps/core/src/db.rs
@@ -1,7 +1,8 @@
 use crate::config::DatabaseConfig;
 use anyhow::{Context, Result};
 use domain::entities::{
-    OrganizationId, ProjectId, SessionId, UserId, UserOrganizationId, UserProjectId,
+    JobId, OrganizationId, PipelineId, ProjectId, SessionId, UserId, UserOrganizationId,
+    UserProjectId,
 };
 use surrealdb::Surreal;
 use surrealdb::engine::any::Any;
@@ -32,6 +33,8 @@ pub async fn init_db(config: &DatabaseConfig) -> Result<Surreal<Any>> {
         ProjectId::table_name(),
         UserOrganizationId::table_name(),
         UserProjectId::table_name(),
+        PipelineId::table_name(),
+        JobId::table_name(),
     ];
 
     let ddl = tables

--- a/libs/surreal-casbin-adapter/src/lib.rs
+++ b/libs/surreal-casbin-adapter/src/lib.rs
@@ -119,10 +119,10 @@ fn load_policy_line(m: &mut dyn Model, rule: &CasbinRule) {
     if values.is_empty() {
         return;
     }
-    if let Some(sec_map) = m.get_mut_model().get_mut(&rule.sec) {
-        if let Some(assertion) = sec_map.get_mut(&rule.ptype) {
-            assertion.get_mut_policy().insert(values);
-        }
+    if let Some(sec_map) = m.get_mut_model().get_mut(&rule.sec)
+        && let Some(assertion) = sec_map.get_mut(&rule.ptype)
+    {
+        assertion.get_mut_policy().insert(values);
     }
 }
 
@@ -407,8 +407,5 @@ impl SurrealAdapter {
 
 // ─── Error helper ─────────────────────────────────────────────────────────────
 fn io_err(e: impl std::fmt::Display) -> casbin::Error {
-    casbin::Error::IoError(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        e.to_string(),
-    ))
+    casbin::Error::IoError(std::io::Error::other(e.to_string()))
 }


### PR DESCRIPTION
Body :                                                                                                                                                                   
  ## Summary                                                                                                                                                               
  - Add empty-list tests for all repository list methods (user, organization, project, user_organization, user_project, pipeline, job)                                     
  - Register Pipeline and Job tables at startup in db.rs                                                                                                                   
  - Fix all 7 clippy warnings across the workspace                                                                                                                         

  ## Test plan                                                                                                                                                             
  - [x] cargo test -p infrastructure — 85 tests pass                                                                                                                       
  - [x] cargo clippy --workspace — 0 warnings                                                                                                                              
  - [x] cargo build --workspace — builds clean 