### PR TITLE
ci: add multi-arch backend image build & promote workflow

### DIFF
--- a/.github/workflows/backend-images.yaml
+++ b/.github/workflows/backend-images.yaml
@@ -1,0 +1,196 @@
+## Build & promote backend Docker images.
+##
+## - push to `back-end`  -> build multi-arch (linux/amd64+arm64) images for changed services
+##                          and publish them as :back-end + :back-end-<sha7>.
+## - push to `dev`       -> retag (no rebuild) the images from the merge source SHA as :dev + :dev-<sha7>.
+## - push to `main`      -> retag (no rebuild) the dev images as :latest + :main-<sha7>.
+##
+## Promotion expects PR merge commits (HEAD^2 = source branch tip).
+## Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN.
+
+name: Backend images
+
+on:
+  push:
+    branches: [back-end, dev, main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Dockerfile'
+      - '.github/workflows/backend-images.yaml'
+
+env:
+  IMAGE_PREFIX: godlyjaaaaj
+  ALL_SERVICES: '["scylla-api","scylla-broker","scylla-agent","scylla-recorder"]'
+
+jobs:
+  detect-changes:
+    name: Detect changed services
+    if: github.ref == 'refs/heads/back-end'
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.compose.outputs.list }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            shared:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'Dockerfile'
+              - 'crates/scylla-core/**'
+              - 'crates/scylla-protocol/**'
+            api:
+              - 'crates/scylla-api/**'
+            broker:
+              - 'crates/scylla-broker/**'
+            agent:
+              - 'crates/scylla-agent/**'
+            recorder:
+              - 'crates/scylla-recorder/**'
+
+      - id: compose
+        run: |
+          if [[ "${{ steps.filter.outputs.shared }}" == "true" ]]; then
+            echo 'list=${{ env.ALL_SERVICES }}' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          svcs=()
+          [[ "${{ steps.filter.outputs.api }}"      == "true" ]] && svcs+=('"scylla-api"')
+          [[ "${{ steps.filter.outputs.broker }}"   == "true" ]] && svcs+=('"scylla-broker"')
+          [[ "${{ steps.filter.outputs.agent }}"    == "true" ]] && svcs+=('"scylla-agent"')
+          [[ "${{ steps.filter.outputs.recorder }}" == "true" ]] && svcs+=('"scylla-recorder"')
+          if [[ ${#svcs[@]} -eq 0 ]]; then
+            echo 'list=[]' >> "$GITHUB_OUTPUT"
+          else
+            IFS=,
+            echo "list=[${svcs[*]}]" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build ${{ matrix.service }}
+    needs: detect-changes
+    if: github.ref == 'refs/heads/back-end' && needs.detect-changes.outputs.services != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.detect-changes.outputs.services) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          build-args: |
+            PACKAGE=${{ matrix.service }}
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:back-end
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:back-end-${{ steps.sha.outputs.short }}
+          cache-from: |
+            type=gha,scope=${{ matrix.service }}
+            type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:buildcache
+          cache-to: |
+            type=gha,scope=${{ matrix.service }},mode=max
+            type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
+
+  promote-dev:
+    name: Promote ${{ matrix.service }} to dev
+    if: github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [scylla-api, scylla-broker, scylla-agent, scylla-recorder]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: refs
+        run: |
+          if ! SOURCE_FULL=$(git rev-parse HEAD^2 2>/dev/null); then
+            echo "::error::HEAD on dev is not a merge commit. Promotion expects a PR merge commit from back-end."
+            exit 1
+          fi
+          echo "source=${SOURCE_FULL::7}" >> "$GITHUB_OUTPUT"
+          echo "current=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Retag back-end -> dev
+        run: |
+          src="${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:back-end-${{ steps.refs.outputs.source }}"
+          if ! docker buildx imagetools inspect "$src" >/dev/null 2>&1; then
+            echo "::error::Source image $src not found. Push back-end first or merge a back-end commit that built successfully."
+            exit 1
+          fi
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:dev \
+            -t ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:dev-${{ steps.refs.outputs.current }} \
+            "$src"
+
+  promote-main:
+    name: Promote ${{ matrix.service }} to main
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [scylla-api, scylla-broker, scylla-agent, scylla-recorder]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: refs
+        run: |
+          if ! SOURCE_FULL=$(git rev-parse HEAD^2 2>/dev/null); then
+            echo "::error::HEAD on main is not a merge commit. Promotion expects a PR merge commit from dev."
+            exit 1
+          fi
+          echo "source=${SOURCE_FULL::7}" >> "$GITHUB_OUTPUT"
+          echo "current=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Retag dev -> main
+        run: |
+          src="${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:dev-${{ steps.refs.outputs.source }}"
+          if ! docker buildx imagetools inspect "$src" >/dev/null 2>&1; then
+            echo "::error::Source image $src not found. Promote to dev first."
+            exit 1
+          fi
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:latest \
+            -t ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:main-${{ steps.refs.outputs.current }} \
+            "$src"


### PR DESCRIPTION
Build linux/amd64+arm64 images on push to back-end (path-filtered per crate), then retag by digest to dev/main on PR merges. Avoids redundant rebuilds via GHA + registry buildcache and digest-only promotion.

Tags per service (godlyjaaaaj/scylla-{api,broker,agent,recorder}):
- back-end: :back-end, :back-end-<sha7>
- dev:      :dev,      :dev-<sha7>      (retag from back-end-<HEAD^2>)
- main:     :latest,   :main-<sha7>     (retag from dev-<HEAD^2>)

Requires secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->