### PR TITLE
ci: fix Blacksmith arm64 runner label

### DIFF
--- a/.github/workflows/backend-images.yaml
+++ b/.github/workflows/backend-images.yaml
@@ -82,7 +82,7 @@ jobs:
         service: ${{ fromJson(needs.detect-changes.outputs.services) }}
         platform:
           - { arch: amd64, runner: blacksmith-4vcpu-ubuntu-2404,       docker: linux/amd64 }
-          - { arch: arm64, runner: blacksmith-4vcpu-ubuntu-2404-arm64, docker: linux/arm64 }
+          - { arch: arm64, runner: blacksmith-4vcpu-ubuntu-2404-arm, docker: linux/arm64 }
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Blacksmith arm runner suffix is `-arm`, not `-arm64`. The mislabeled job sat in queue forever waiting for a non-existent runner pool.

Per docs.blacksmith.sh: blacksmith-<N>vcpu-ubuntu-<2204|2404>[-arm].

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->