### PR TITLE
feat: navigate to a project organization when created

### DIFF
--- a/apps/frontend/src/modules/features/project/presentation/ui/AddProjectDialog.tsx
+++ b/apps/frontend/src/modules/features/project/presentation/ui/AddProjectDialog.tsx
@@ -8,6 +8,8 @@ import {
   type FormItem,
   FormItemType,
 } from '@shared/presentation/models/scylla-form.model.ts';
+import { useNavigate } from 'react-router-dom';
+import { useContextStore } from '@shared/presentation/stores/use-context.store.ts';
 
 interface AddProjectDialogProps {
   open: boolean;
@@ -16,6 +18,8 @@ interface AddProjectDialogProps {
 
 export function AddProjectDialog({ open, setOpen }: AddProjectDialogProps) {
   const { t } = useLingui();
+  const navigate = useNavigate();
+  const setOrganization = useContextStore(state => state.setOrganization);
   const createProject = useCreateProject();
   const { organizations } = useOrganizations();
 
@@ -48,7 +52,20 @@ export function AddProjectDialog({ open, setOpen }: AddProjectDialogProps) {
       return;
     }
 
-    createProject.mutate({ name, organizationId }, { onSuccess: () => setOpen(false) });
+    const selectedOrganization = organizations?.find(org => org.organizationId === organizationId);
+
+    createProject.mutate(
+      { name, organizationId },
+      {
+        onSuccess: () => {
+          setOpen(false);
+          if (selectedOrganization) {
+            setOrganization(organizationId, selectedOrganization.name);
+          }
+          navigate('/projects');
+        },
+      },
+    );
   };
 
   return (


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->