### PR TITLE
Github Workflows

### DIFF
--- a/.github/workflows/backend-images.yaml
+++ b/.github/workflows/backend-images.yaml
@@ -1,0 +1,196 @@
+## Build & promote backend Docker images.
+##
+## - push to `back-end`  -> build multi-arch (linux/amd64+arm64) images for changed services
+##                          and publish them as :back-end + :back-end-<sha7>.
+## - push to `dev`       -> retag (no rebuild) the images from the merge source SHA as :dev + :dev-<sha7>.
+## - push to `main`      -> retag (no rebuild) the dev images as :latest + :main-<sha7>.
+##
+## Promotion expects PR merge commits (HEAD^2 = source branch tip).
+## Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN.
+
+name: Backend images
+
+on:
+  push:
+    branches: [back-end, dev, main]
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Dockerfile'
+      - '.github/workflows/backend-images.yaml'
+
+env:
+  IMAGE_PREFIX: godlyjaaaaj
+  ALL_SERVICES: '["scylla-api","scylla-broker","scylla-agent","scylla-recorder"]'
+
+jobs:
+  detect-changes:
+    name: Detect changed services
+    if: github.ref == 'refs/heads/back-end'
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.compose.outputs.list }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            shared:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'Dockerfile'
+              - 'crates/scylla-core/**'
+              - 'crates/scylla-protocol/**'
+            api:
+              - 'crates/scylla-api/**'
+            broker:
+              - 'crates/scylla-broker/**'
+            agent:
+              - 'crates/scylla-agent/**'
+            recorder:
+              - 'crates/scylla-recorder/**'
+
+      - id: compose
+        run: |
+          if [[ "${{ steps.filter.outputs.shared }}" == "true" ]]; then
+            echo 'list=${{ env.ALL_SERVICES }}' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          svcs=()
+          [[ "${{ steps.filter.outputs.api }}"      == "true" ]] && svcs+=('"scylla-api"')
+          [[ "${{ steps.filter.outputs.broker }}"   == "true" ]] && svcs+=('"scylla-broker"')
+          [[ "${{ steps.filter.outputs.agent }}"    == "true" ]] && svcs+=('"scylla-agent"')
+          [[ "${{ steps.filter.outputs.recorder }}" == "true" ]] && svcs+=('"scylla-recorder"')
+          if [[ ${#svcs[@]} -eq 0 ]]; then
+            echo 'list=[]' >> "$GITHUB_OUTPUT"
+          else
+            IFS=,
+            echo "list=[${svcs[*]}]" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build ${{ matrix.service }}
+    needs: detect-changes
+    if: github.ref == 'refs/heads/back-end' && needs.detect-changes.outputs.services != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.detect-changes.outputs.services) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          build-args: |
+            PACKAGE=${{ matrix.service }}
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:back-end
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:back-end-${{ steps.sha.outputs.short }}
+          cache-from: |
+            type=gha,scope=${{ matrix.service }}
+            type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:buildcache
+          cache-to: |
+            type=gha,scope=${{ matrix.service }},mode=max
+            type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
+
+  promote-dev:
+    name: Promote ${{ matrix.service }} to dev
+    if: github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [scylla-api, scylla-broker, scylla-agent, scylla-recorder]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: refs
+        run: |
+          if ! SOURCE_FULL=$(git rev-parse HEAD^2 2>/dev/null); then
+            echo "::error::HEAD on dev is not a merge commit. Promotion expects a PR merge commit from back-end."
+            exit 1
+          fi
+          echo "source=${SOURCE_FULL::7}" >> "$GITHUB_OUTPUT"
+          echo "current=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Retag back-end -> dev
+        run: |
+          src="${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:back-end-${{ steps.refs.outputs.source }}"
+          if ! docker buildx imagetools inspect "$src" >/dev/null 2>&1; then
+            echo "::error::Source image $src not found. Push back-end first or merge a back-end commit that built successfully."
+            exit 1
+          fi
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:dev \
+            -t ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:dev-${{ steps.refs.outputs.current }} \
+            "$src"
+
+  promote-main:
+    name: Promote ${{ matrix.service }} to main
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [scylla-api, scylla-broker, scylla-agent, scylla-recorder]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: refs
+        run: |
+          if ! SOURCE_FULL=$(git rev-parse HEAD^2 2>/dev/null); then
+            echo "::error::HEAD on main is not a merge commit. Promotion expects a PR merge commit from dev."
+            exit 1
+          fi
+          echo "source=${SOURCE_FULL::7}" >> "$GITHUB_OUTPUT"
+          echo "current=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Retag dev -> main
+        run: |
+          src="${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:dev-${{ steps.refs.outputs.source }}"
+          if ! docker buildx imagetools inspect "$src" >/dev/null 2>&1; then
+            echo "::error::Source image $src not found. Promote to dev first."
+            exit 1
+          fi
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:latest \
+            -t ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:main-${{ steps.refs.outputs.current }} \
+            "$src"

--- a/.github/workflows/backend-images.yaml
+++ b/.github/workflows/backend-images.yaml
@@ -23,7 +23,6 @@ on:
 env:
   IMAGE_PREFIX: godlyjaaaaj
   ALL_SERVICES: '["scylla-api","scylla-broker","scylla-agent","scylla-recorder"]'
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   detect-changes:
@@ -33,10 +32,10 @@ jobs:
     outputs:
       services: ${{ steps.compose.outputs.list }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             shared:
@@ -85,17 +84,17 @@ jobs:
           - { arch: amd64, runner: blacksmith-2vcpu-ubuntu-2404,       docker: linux/amd64 }
           - { arch: arm64, runner: blacksmith-2vcpu-ubuntu-2404-arm64, docker: linux/arm64 }
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: useblacksmith/setup-docker-builder@v1
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - id: build
-        uses: useblacksmith/build-push-action@v1
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: Dockerfile
@@ -114,7 +113,7 @@ jobs:
           digest='${{ steps.build.outputs.digest }}'
           touch "/tmp/digests/${digest#sha256:}"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.service }}-${{ matrix.platform.arch }}
           path: /tmp/digests/*
@@ -134,15 +133,15 @@ jobs:
       - id: sha
         run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-${{ matrix.service }}-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -168,7 +167,7 @@ jobs:
       matrix:
         service: [scylla-api, scylla-broker, scylla-agent, scylla-recorder]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -181,9 +180,9 @@ jobs:
           echo "source=${SOURCE_FULL::7}" >> "$GITHUB_OUTPUT"
           echo "current=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -209,7 +208,7 @@ jobs:
       matrix:
         service: [scylla-api, scylla-broker, scylla-agent, scylla-recorder]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -222,9 +221,9 @@ jobs:
           echo "source=${SOURCE_FULL::7}" >> "$GITHUB_OUTPUT"
           echo "current=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/backend-images.yaml
+++ b/.github/workflows/backend-images.yaml
@@ -82,7 +82,7 @@ jobs:
         service: ${{ fromJson(needs.detect-changes.outputs.services) }}
         platform:
           - { arch: amd64, runner: blacksmith-4vcpu-ubuntu-2404,       docker: linux/amd64 }
-          - { arch: arm64, runner: blacksmith-4vcpu-ubuntu-2404-arm64, docker: linux/arm64 }
+          - { arch: arm64, runner: blacksmith-4vcpu-ubuntu-2404-arm, docker: linux/arm64 }
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/backend-images.yaml
+++ b/.github/workflows/backend-images.yaml
@@ -28,7 +28,7 @@ jobs:
   detect-changes:
     name: Detect changed services
     if: github.ref == 'refs/heads/back-end'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       services: ${{ steps.compose.outputs.list }}
     steps:
@@ -81,8 +81,8 @@ jobs:
       matrix:
         service: ${{ fromJson(needs.detect-changes.outputs.services) }}
         platform:
-          - { arch: amd64, runner: blacksmith-2vcpu-ubuntu-2404,       docker: linux/amd64 }
-          - { arch: arm64, runner: blacksmith-2vcpu-ubuntu-2404-arm64, docker: linux/arm64 }
+          - { arch: amd64, runner: blacksmith-4vcpu-ubuntu-2404,       docker: linux/amd64 }
+          - { arch: arm64, runner: blacksmith-4vcpu-ubuntu-2404-arm64, docker: linux/arm64 }
     steps:
       - uses: actions/checkout@v6
 
@@ -103,6 +103,7 @@ jobs:
           provenance: false
           build-args: |
             PACKAGE=${{ matrix.service }}
+            CARGO_BUILD_JOBS=2
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.service }},push-by-digest=true,name-canonical=true
           cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:buildcache-${{ matrix.platform.arch }}
           cache-to: type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:buildcache-${{ matrix.platform.arch }},mode=max,image-manifest=true,oci-mediatypes=true
@@ -124,7 +125,7 @@ jobs:
     name: Publish ${{ matrix.service }} manifest
     needs: [detect-changes, build]
     if: github.ref == 'refs/heads/back-end' && needs.detect-changes.outputs.services != '[]'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
@@ -161,7 +162,7 @@ jobs:
   promote-dev:
     name: Promote ${{ matrix.service }} to dev
     if: github.ref == 'refs/heads/dev'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
@@ -202,7 +203,7 @@ jobs:
   promote-main:
     name: Promote ${{ matrix.service }} to main
     if: github.ref == 'refs/heads/main'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/backend-images.yaml
+++ b/.github/workflows/backend-images.yaml
@@ -23,6 +23,7 @@ on:
 env:
   IMAGE_PREFIX: godlyjaaaaj
   ALL_SERVICES: '["scylla-api","scylla-broker","scylla-agent","scylla-recorder"]'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   detect-changes:
@@ -32,7 +33,7 @@ jobs:
     outputs:
       services: ${{ steps.compose.outputs.list }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - id: filter
         uses: dorny/paths-filter@v3
@@ -84,7 +85,7 @@ jobs:
           - { arch: amd64, runner: blacksmith-2vcpu-ubuntu-2404,       docker: linux/amd64 }
           - { arch: arm64, runner: blacksmith-2vcpu-ubuntu-2404-arm64, docker: linux/arm64 }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: docker/setup-buildx-action@v3
 
@@ -113,7 +114,7 @@ jobs:
           digest='${{ steps.build.outputs.digest }}'
           touch "/tmp/digests/${digest#sha256:}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: digests-${{ matrix.service }}-${{ matrix.platform.arch }}
           path: /tmp/digests/*
@@ -133,7 +134,7 @@ jobs:
       - id: sha
         run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: /tmp/digests
           pattern: digests-${{ matrix.service }}-*
@@ -167,7 +168,7 @@ jobs:
       matrix:
         service: [scylla-api, scylla-broker, scylla-agent, scylla-recorder]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -208,7 +209,7 @@ jobs:
       matrix:
         service: [scylla-api, scylla-broker, scylla-agent, scylla-recorder]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/backend-images.yaml
+++ b/.github/workflows/backend-images.yaml
@@ -1,7 +1,7 @@
-## Build & promote backend Docker images.
+## Build & promote backend Docker images on Blacksmith runners.
 ##
-## - push to `back-end`  -> build multi-arch (linux/amd64+arm64) images for changed services
-##                          and publish them as :back-end + :back-end-<sha7>.
+## - push to `back-end`  -> per-platform native build (amd64 + arm64) of changed services,
+##                          push by-digest, then merge-manifest publishes :back-end + :back-end-<sha7>.
 ## - push to `dev`       -> retag (no rebuild) the images from the merge source SHA as :dev + :dev-<sha7>.
 ## - push to `main`      -> retag (no rebuild) the dev images as :latest + :main-<sha7>.
 ##
@@ -28,7 +28,7 @@ jobs:
   detect-changes:
     name: Detect changed services
     if: github.ref == 'refs/heads/back-end'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       services: ${{ steps.compose.outputs.list }}
     steps:
@@ -72,21 +72,20 @@ jobs:
           fi
 
   build:
-    name: Build ${{ matrix.service }}
+    name: Build ${{ matrix.service }} (${{ matrix.platform.arch }})
     needs: detect-changes
     if: github.ref == 'refs/heads/back-end' && needs.detect-changes.outputs.services != '[]'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
       matrix:
         service: ${{ fromJson(needs.detect-changes.outputs.services) }}
+        platform:
+          - { arch: amd64, runner: blacksmith-2vcpu-ubuntu-2404,       docker: linux/amd64 }
+          - { arch: arm64, runner: blacksmith-2vcpu-ubuntu-2404-arm64, docker: linux/arm64 }
     steps:
       - uses: actions/checkout@v4
 
-      - id: sha
-        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -94,29 +93,75 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - id: build
+        uses: useblacksmith/build-push-action@v1
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform.docker }}
           push: true
           provenance: false
           build-args: |
             PACKAGE=${{ matrix.service }}
-          tags: |
-            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:back-end
-            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:back-end-${{ steps.sha.outputs.short }}
-          cache-from: |
-            type=gha,scope=${{ matrix.service }}
-            type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:buildcache
-          cache-to: |
-            type=gha,scope=${{ matrix.service }},mode=max
-            type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.service }},push-by-digest=true,name-canonical=true
+          cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:buildcache-${{ matrix.platform.arch }}
+          cache-to: type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:buildcache-${{ matrix.platform.arch }},mode=max,image-manifest=true,oci-mediatypes=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest='${{ steps.build.outputs.digest }}'
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.service }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Publish ${{ matrix.service }} manifest
+    needs: [detect-changes, build]
+    if: github.ref == 'refs/heads/back-end' && needs.detect-changes.outputs.services != '[]'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.detect-changes.outputs.services) }}
+    steps:
+      - id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.service }}-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create manifest list
+        working-directory: /tmp/digests
+        run: |
+          refs=()
+          for f in *; do
+            refs+=("${{ env.IMAGE_PREFIX }}/${{ matrix.service }}@sha256:${f}")
+          done
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:back-end \
+            -t ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:back-end-${{ steps.sha.outputs.short }} \
+            "${refs[@]}"
 
   promote-dev:
     name: Promote ${{ matrix.service }} to dev
     if: github.ref == 'refs/heads/dev'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
@@ -157,7 +202,7 @@ jobs:
   promote-main:
     name: Promote ${{ matrix.service }} to main
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ WORKDIR /app
 COPY . .
 
 ARG PACKAGE
+ARG CARGO_BUILD_JOBS=2
+ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,sharing=locked \


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building, publishing, and promoting backend Docker images for multiple services, and makes a minor improvement to the `Dockerfile` to allow configuring parallel build jobs. The workflow automates per-platform native builds, image promotion across branches, and uses caching for efficient builds.

**CI/CD workflow automation:**
* Adds `.github/workflows/backend-images.yaml` to automate building, publishing, and promoting Docker images for backend services (`scylla-api`, `scylla-broker`, `scylla-agent`, `scylla-recorder`) across `back-end`, `dev`, and `main` branches, supporting both `amd64` and `arm64` platforms, and using image digests and manifest lists for multi-arch support.
* Implements change detection to only build images for services affected by code changes, optimizing CI resource usage.
* Sets up promotion jobs to retag images between branches (`back-end` → `dev` → `main`) without rebuilding, enforcing promotion only on PR merge commits.

**Build performance and configuration:**
* Updates `Dockerfile` to accept a `CARGO_BUILD_JOBS` build argument and environment variable, allowing control over parallel Rust build jobs for faster and more efficient builds.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->