### PR TITLE
Merge breadcrumbs-emphasis and back-buttons into front-end

### DIFF
--- a/apps/frontend/src/modules/core/presentation/ui/router/ContextCleaner.wrapper.tsx
+++ b/apps/frontend/src/modules/core/presentation/ui/router/ContextCleaner.wrapper.tsx
@@ -16,7 +16,11 @@ export const ContextCleanerWrapper = () => {
       setProject(null, null);
     }
 
-    if (pipeline?.id && !location.pathname.includes('/edit/')) {
+    if (
+      pipeline?.id &&
+      !location.pathname.includes('/edit/') &&
+      !location.pathname.includes('/pipelines/')
+    ) {
       console.log('Suppression du pipeline car on a quitté la page édit');
       setPipeline(null, null);
     }

--- a/apps/frontend/src/modules/core/presentation/ui/router/Core.router.tsx
+++ b/apps/frontend/src/modules/core/presentation/ui/router/Core.router.tsx
@@ -62,7 +62,7 @@ export const CoreRouter = createBrowserRouter([
                     element: <PipelineCreationPage />,
                     handle: {
                       breadcrumb: ({ pipelineName }: BreadcrumbParams) =>
-                        `Pipeline #${pipelineName}`,
+                        `Pipeline #${pipelineName} - Edit`,
                     },
                   },
                   {
@@ -70,7 +70,7 @@ export const CoreRouter = createBrowserRouter([
                     element: <JobsPage />,
                     handle: {
                       breadcrumb: ({ pipelineName }: BreadcrumbParams) =>
-                        `${pipelineName ? `#${pipelineName}` : 'Pipeline'} - Jobs`,
+                        `Pipeline #${pipelineName} - Jobs`,
                     },
                   },
                 ],

--- a/apps/frontend/src/modules/features/jobs/presentation/ui/JobsHeader.tsx
+++ b/apps/frontend/src/modules/features/jobs/presentation/ui/JobsHeader.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@shadcn';
-import { Trash, RefreshCw, ArrowLeft } from 'lucide-react';
+import { Trash, RefreshCw } from 'lucide-react';
+import { BackButton } from '@shared/presentation/ui/BackButton.tsx';
 import { useDeleteJobs } from '@/modules/features/jobs/presentation/hooks/use-delete-jobs.ts';
 import { useJobsStore } from '@/modules/features/jobs/presentation/stores/use-jobs.store.ts';
 import { useState } from 'react';
@@ -39,9 +40,7 @@ export const JobsHeader = ({
   return (
     <div className={'flex flex-col gap-3'}>
       <div className='flex items-center gap-2'>
-        <Button variant='ghost' size='icon' onClick={onBack} className='h-8 w-8'>
-          <ArrowLeft className='size-4' />
-        </Button>
+        <BackButton iconOnly onClick={onBack} />
         <div>
           <h1 className='text-3xl font-bold tracking-tight'>
             <span className='text-primary'>{numberOfJobs}</span>{' '}

--- a/apps/frontend/src/modules/features/pipeline/locales/en/messages.po
+++ b/apps/frontend/src/modules/features/pipeline/locales/en/messages.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "Actions"
 msgstr "Actions"
 
-#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:19
+#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:27
 msgid "Blueprint"
 msgstr "Blueprint"
 
@@ -23,7 +23,7 @@ msgstr "Blueprint"
 #~ msgid "Clear"
 #~ msgstr "Clear"
 
-#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:32
+#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:41
 msgid "Create"
 msgstr "Create"
 
@@ -70,7 +70,7 @@ msgstr "New pipeline"
 msgid "No pipeline found"
 msgstr "No pipeline found"
 
-#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:26
+#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:35
 msgid "Pipeline created successfully"
 msgstr "Pipeline created successfully"
 
@@ -88,7 +88,7 @@ msgstr "Reactflow canvas here"
 msgid "Run"
 msgstr "Run"
 
-#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:16
+#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:24
 msgid "Scripting"
 msgstr "Scripting"
 

--- a/apps/frontend/src/modules/features/pipeline/locales/fr/messages.po
+++ b/apps/frontend/src/modules/features/pipeline/locales/fr/messages.po
@@ -15,7 +15,7 @@ msgstr ""
 msgid "Actions"
 msgstr ""
 
-#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:19
+#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:27
 msgid "Blueprint"
 msgstr ""
 
@@ -23,7 +23,7 @@ msgstr ""
 #~ msgid "Clear"
 #~ msgstr "Effacer"
 
-#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:32
+#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:41
 msgid "Create"
 msgstr ""
 
@@ -70,7 +70,7 @@ msgstr "Nouveau pipeline"
 msgid "No pipeline found"
 msgstr "Aucun pipeline trouvé"
 
-#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:26
+#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:35
 msgid "Pipeline created successfully"
 msgstr ""
 
@@ -88,7 +88,7 @@ msgstr ""
 msgid "Run"
 msgstr "Exécuter"
 
-#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:16
+#: src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx:24
 msgid "Scripting"
 msgstr ""
 

--- a/apps/frontend/src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx
+++ b/apps/frontend/src/modules/features/pipeline/presentation/ui/creation/PipelineCreationTopbar.tsx
@@ -1,5 +1,7 @@
 import { Button } from '@shadcn';
 import { TabsList, TabsTrigger } from '@shadcn/tabs.tsx';
+import { BackButton } from '@shared/presentation/ui/BackButton.tsx';
+import { useScyllaNavigate } from '@shared/presentation/hooks/use-scylla-navigate.ts';
 import { useDependencies } from '@core/presentation/hooks/use-dependencies.ts';
 import { useScriptStore } from '@/modules/features/pipeline/presentation/stores/use-script.store.ts';
 import { toast } from '@shared/presentation/utils/toast.ts';
@@ -7,30 +9,36 @@ import { Trans, useLingui } from '@lingui/react/macro';
 
 export const PipelineCreationTopbar = () => {
   const { t } = useLingui();
+  const { goBack } = useScyllaNavigate();
   const script = useScriptStore(state => state.script);
   const createPipeline = useDependencies().pipeline.createPipeline;
   return (
-    <div className={'flex justify-between w-full'}>
-      <TabsList>
-        <TabsTrigger value='scripting'>
-          <Trans>Scripting</Trans>
-        </TabsTrigger>
-        <TabsTrigger value='blueprint'>
-          <Trans>Blueprint</Trans>
-        </TabsTrigger>
-      </TabsList>
-      <Button
-        onClick={() => {
-          createPipeline.execute(script).then(res => {
-            res.fold({
-              onSuccess: () => toast.success(t`Pipeline created successfully`),
-              onError: err => toast.error(err.message),
+    <div className='flex flex-col gap-4 w-full'>
+      <div className='flex items-center justify-between gap-4'>
+        <div className='flex items-center gap-3'>
+          <BackButton iconOnly onClick={() => goBack()} />
+          <TabsList>
+            <TabsTrigger value='scripting'>
+              <Trans>Scripting</Trans>
+            </TabsTrigger>
+            <TabsTrigger value='blueprint'>
+              <Trans>Blueprint</Trans>
+            </TabsTrigger>
+          </TabsList>
+        </div>
+        <Button
+          onClick={() => {
+            createPipeline.execute(script).then(res => {
+              res.fold({
+                onSuccess: () => toast.success(t`Pipeline created successfully`),
+                onError: err => toast.error(err.message),
+              });
             });
-          });
-        }}
-      >
-        <Trans>Create</Trans>
-      </Button>
+          }}
+        >
+          <Trans>Create</Trans>
+        </Button>
+      </div>
     </div>
   );
 };

--- a/apps/frontend/src/modules/features/pipeline/presentation/ui/dashboard/DashboardPipeline.page.tsx
+++ b/apps/frontend/src/modules/features/pipeline/presentation/ui/dashboard/DashboardPipeline.page.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { usePipelines } from '../../hooks/use-pipelines.ts';
 import { usePipelineJobs } from '../../hooks/use-pipeline-jobs.ts';
 import { ErrorState } from '@shared/presentation/ui/ErrorState.tsx';
@@ -8,6 +8,7 @@ import { PipelineDashboardHeader } from '@/modules/features/pipeline/presentatio
 import { PipelineTable } from '@/modules/features/pipeline/presentation/ui/dashboard/pipeline-table/PipelineTable.tsx';
 
 export const DashboardPipelinePage = () => {
+  const navigate = useNavigate();
   const { projectId } = useParams();
   const { isLoading, pipelines, isError, errorMessage, paginationInfo, setPage } = usePipelines(
     projectId!,
@@ -24,9 +25,14 @@ export const DashboardPipelinePage = () => {
     return <ErrorState message={String(errorMessage) || 'Unable to load pipelines'} />;
   }
 
+  const handleBack = () => navigate('/projects');
+
   return (
     <div className='flex flex-col gap-4 w-full h-full p-4'>
-      <PipelineDashboardHeader numberOfPipelines={paginationInfo?.totalCount ?? pipelines.length} />
+      <PipelineDashboardHeader
+        numberOfPipelines={paginationInfo?.totalCount ?? pipelines.length}
+        onBack={handleBack}
+      />
       <div className='flex-1 min-h-0 overflow-auto'>
         <div className='relative'>
           {pipelines.length > 0 ? (

--- a/apps/frontend/src/modules/features/pipeline/presentation/ui/dashboard/PipelineDashboardHeader.tsx
+++ b/apps/frontend/src/modules/features/pipeline/presentation/ui/dashboard/PipelineDashboardHeader.tsx
@@ -1,14 +1,18 @@
 import { useScyllaNavigate } from '@shared/presentation/hooks/use-scylla-navigate.ts';
 import { useSelection } from '@shared/presentation/hooks/use-selection.ts';
 import { Trans } from '@lingui/react/macro';
-import { FeatureHeader } from '@shared/presentation/ui';
+import { FeatureHeader, BackButton } from '@shared/presentation/ui';
 import { useDeletePipeline } from '@/modules/features/pipeline/presentation/hooks/use-delete-pipeline.ts';
 
 interface PipelineDashboardHeaderProps {
   numberOfPipelines: number;
+  onBack: () => void;
 }
 
-export const PipelineDashboardHeader = ({ numberOfPipelines }: PipelineDashboardHeaderProps) => {
+export const PipelineDashboardHeader = ({
+  numberOfPipelines,
+  onBack,
+}: PipelineDashboardHeaderProps) => {
   const { goToCreatePipeline } = useScyllaNavigate();
   const deletePipeline = useDeletePipeline();
   const { selectedIds, clearSelection } = useSelection('pipelines');
@@ -20,14 +24,17 @@ export const PipelineDashboardHeader = ({ numberOfPipelines }: PipelineDashboard
   };
 
   return (
-    <FeatureHeader
-      count={numberOfPipelines}
-      label='Pipeline'
-      selectedCount={selectedIds.length}
-      onClearSelection={clearSelection}
-      onDeleteSelection={handleDelete}
-      onNew={goToCreatePipeline}
-      newLabel={<Trans>New pipeline</Trans>}
-    />
+    <div className='flex items-center gap-4 w-full'>
+      <BackButton iconOnly onClick={onBack} />
+      <FeatureHeader
+        count={numberOfPipelines}
+        label='Pipeline'
+        selectedCount={selectedIds.length}
+        onClearSelection={clearSelection}
+        onDeleteSelection={handleDelete}
+        onNew={goToCreatePipeline}
+        newLabel={<Trans>New pipeline</Trans>}
+      />
+    </div>
   );
 };

--- a/apps/frontend/src/modules/features/pipeline/presentation/ui/dashboard/pipeline-table/PipelineTable.tsx
+++ b/apps/frontend/src/modules/features/pipeline/presentation/ui/dashboard/pipeline-table/PipelineTable.tsx
@@ -39,8 +39,8 @@ export const PipelineTable = ({
     onEdit: pipeline => {
       goToEditPipeline(pipeline);
     },
-    onViewJobs: pipelineId => {
-      goToJobs(pipelineId);
+    onViewJobs: pipeline => {
+      goToJobs(pipeline);
     },
     runningPipelines: runningPipelines,
     jobsByPipelineId,

--- a/apps/frontend/src/modules/features/pipeline/presentation/ui/dashboard/pipeline-table/columns.tsx
+++ b/apps/frontend/src/modules/features/pipeline/presentation/ui/dashboard/pipeline-table/columns.tsx
@@ -10,7 +10,7 @@ import { Trans } from '@lingui/react/macro';
 type PipelineColumnMeta = {
   onRun: (pipelineId: string) => void;
   onEdit: (pipeline: PipelineSummary) => void;
-  onViewJobs: (pipelineId: string) => void;
+  onViewJobs: (pipeline: PipelineSummary) => void;
 
   runningPipelines: Set<string>;
 
@@ -93,7 +93,7 @@ export const createPipelineColumns = (meta: PipelineColumnMeta): ColumnDef<Pipel
         }}
         onViewJobs={e => {
           e.stopPropagation();
-          meta.onViewJobs(row.original.pipelineId);
+          meta.onViewJobs(row.original);
         }}
         isRunning={meta.runningPipelines.has(row.original.pipelineId)}
       />

--- a/apps/frontend/src/modules/features/user/locales/en/messages.po
+++ b/apps/frontend/src/modules/features/user/locales/en/messages.po
@@ -21,6 +21,10 @@ msgstr "Actions"
 msgid "Active account"
 msgstr "Active account"
 
+#: src/modules/features/user/presentation/ui/settings/UserSettings.page.tsx:21
+msgid "Back"
+msgstr "Back"
+
 #: src/modules/features/user/presentation/ui/admin/AddUserDialog.tsx:53
 msgid "Create a new user"
 msgstr "Create a new user"
@@ -82,6 +86,10 @@ msgstr "User information"
 #: src/modules/features/user/presentation/ui/settings/UserInformation.tsx:37
 msgid "User information not available"
 msgstr "User information not available"
+
+#: src/modules/features/user/presentation/ui/settings/UserSettings.page.tsx:24
+msgid "User settings"
+msgstr "User settings"
 
 #: src/modules/features/user/presentation/ui/admin/AddUserDialog.tsx:23
 msgid "Username"

--- a/apps/frontend/src/modules/features/user/locales/fr/messages.po
+++ b/apps/frontend/src/modules/features/user/locales/fr/messages.po
@@ -21,6 +21,10 @@ msgstr ""
 msgid "Active account"
 msgstr ""
 
+#: src/modules/features/user/presentation/ui/settings/UserSettings.page.tsx:21
+msgid "Back"
+msgstr ""
+
 #: src/modules/features/user/presentation/ui/admin/AddUserDialog.tsx:53
 msgid "Create a new user"
 msgstr ""
@@ -81,6 +85,10 @@ msgstr ""
 
 #: src/modules/features/user/presentation/ui/settings/UserInformation.tsx:37
 msgid "User information not available"
+msgstr ""
+
+#: src/modules/features/user/presentation/ui/settings/UserSettings.page.tsx:24
+msgid "User settings"
 msgstr ""
 
 #: src/modules/features/user/presentation/ui/admin/AddUserDialog.tsx:23

--- a/apps/frontend/src/modules/features/user/presentation/ui/settings/UserSettings.page.tsx
+++ b/apps/frontend/src/modules/features/user/presentation/ui/settings/UserSettings.page.tsx
@@ -3,27 +3,40 @@ import { div } from 'framer-motion/m';
 import { Card, CardContent, CardHeader, CardTitle } from '@shadcn';
 import { UserInformation } from '@/modules/features/user/presentation/ui/settings/UserInformation.tsx';
 import { useParams } from 'react-router-dom';
+import { useScyllaNavigate } from '@shared/presentation/hooks/use-scylla-navigate.ts';
+import { BackButton } from '@shared/presentation/ui/BackButton.tsx';
+import { Trans } from '@lingui/react/macro';
 
 //TODO: change and list only organization that the user is in
 // (pass it as a props from Organization module)
 export const UserSettingsPage = () => {
   const { userId } = useParams();
+  const { goBack } = useScyllaNavigate();
 
   return (
-    <div className='flex space-x-6 bg-background'>
-      <div className='w-1/2'>
-        <UserInformation userId={userId ?? localStorage.getItem('userId') ?? undefined} />
+    <div className='flex flex-col gap-4 w-full p-2'>
+      <div className='flex items-center gap-4'>
+        <BackButton iconOnly onClick={() => goBack()} />
+        <h1 className='text-3xl font-bold'>
+          <Trans>User settings</Trans>
+        </h1>
       </div>
 
-      <div className='w-1/2'>
-        <Card className='w-full'>
-          <CardHeader>
-            <CardTitle>Organizations: </CardTitle>
-          </CardHeader>
-          <CardContent className='space-y-4'>
-            <OrganizationList Wrapper={div} />
-          </CardContent>
-        </Card>
+      <div className='flex space-x-6 bg-background'>
+        <div className='w-1/2'>
+          <UserInformation userId={userId ?? localStorage.getItem('userId') ?? undefined} />
+        </div>
+
+        <div className='w-1/2'>
+          <Card className='w-full'>
+            <CardHeader>
+              <CardTitle>Organizations: </CardTitle>
+            </CardHeader>
+            <CardContent className='space-y-4'>
+              <OrganizationList Wrapper={div} />
+            </CardContent>
+          </Card>
+        </div>
       </div>
     </div>
   );

--- a/apps/frontend/src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx
+++ b/apps/frontend/src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx
@@ -3,8 +3,7 @@ import { useWorker } from '@/modules/features/workers/presentation/hooks/use-wor
 import { ErrorState } from '@shared/presentation/ui/ErrorState.tsx';
 import { formatDate } from '@shared/utils/date-utils.ts';
 import { useScyllaNavigate } from '@shared/presentation/hooks/use-scylla-navigate.ts';
-import { Button } from '@shadcn';
-import { ArrowLeft } from 'lucide-react';
+import { BackButton } from '@shared/presentation/ui/BackButton.tsx';
 import { Trans } from '@lingui/react/macro';
 
 export const WorkerDetailsPage = () => {
@@ -27,10 +26,7 @@ export const WorkerDetailsPage = () => {
               <Trans>Information about the selected worker.</Trans>
             </p>
           </div>
-          <Button variant='outline' onClick={() => goBack()}>
-            <ArrowLeft className='mr-2 h-4 w-4' />
-            <Trans>Back</Trans>
-          </Button>
+          <BackButton variant='outline' onClick={() => goBack()} label={<Trans>Back</Trans>} />
         </div>
 
         <div className='grid gap-4 sm:grid-cols-2'>

--- a/apps/frontend/src/modules/layout/presentation/ui/ScyllaBreadcrumbs.tsx
+++ b/apps/frontend/src/modules/layout/presentation/ui/ScyllaBreadcrumbs.tsx
@@ -47,23 +47,40 @@ export const ScyllaBreadcrumbs = () => {
       <BreadcrumbList className='gap-2'>
         {crumbs.map((crumb, index) => {
           const isLast = index === crumbs.length - 1;
-          const words = crumb.label.split(' ');
+
+          const firstHashIndex = crumb.label.indexOf('#');
+          let beforeId = crumb.label;
+          let id = '';
+          let afterId = '';
+
+          if (firstHashIndex !== -1) {
+            beforeId = crumb.label.substring(0, firstHashIndex);
+
+            const afterHash = crumb.label.substring(firstHashIndex);
+            const separatorIndex = afterHash.indexOf(' - ');
+
+            if (separatorIndex !== -1) {
+              id = afterHash.substring(0, separatorIndex);
+              afterId = afterHash.substring(separatorIndex);
+            } else {
+              id = afterHash;
+            }
+          }
 
           return (
             <React.Fragment key={crumb.path}>
               <BreadcrumbItem>
                 {isLast ? (
-                  <BreadcrumbPage className='text-slate-900 font-semibold text-sm px-2 py-1 rounded-md bg-slate-50 flex gap-1'>
-                    {words.map((word, i) => {
-                      const lastIndex = words.length - 1;
-                      const isLastWord = words.length > 1 && i === lastIndex;
-
-                      return (
-                        <span key={i} className={isLastWord ? 'text-primary' : 'whitespace-nowrap'}>
-                          {word}
-                        </span>
-                      );
-                    })}
+                  <BreadcrumbPage className='text-slate-900 font-semibold text-sm px-2 py-1 rounded-md bg-slate-50 flex gap-1 items-center'>
+                    {id ? (
+                      <>
+                        <span className='whitespace-nowrap'>{beforeId}</span>
+                        <span className='text-primary'>{id}</span>
+                        <span className='whitespace-nowrap'>{afterId}</span>
+                      </>
+                    ) : (
+                      <span>{crumb.label}</span>
+                    )}
                   </BreadcrumbPage>
                 ) : (
                   <BreadcrumbLink

--- a/apps/frontend/src/modules/shared/presentation/hooks/use-scylla-navigate.ts
+++ b/apps/frontend/src/modules/shared/presentation/hooks/use-scylla-navigate.ts
@@ -30,9 +30,10 @@ export const useScyllaNavigate = () => {
     setPipeline(pipeline.pipelineId, pipeline.name);
   };
 
-  const goToJobs = (pipelineId: string) => {
+  const goToJobs = (pipeline: PipelineSummary) => {
     const projectId = useContextStore.getState().project.id;
-    navigate(`/projects/${projectId}/pipelines/${pipelineId}/jobs`);
+    navigate(`/projects/${projectId}/pipelines/${pipeline.pipelineId}/jobs`);
+    setPipeline(pipeline.pipelineId, pipeline.name);
   };
 
   const goToUserSettings = (userId?: string) => {

--- a/apps/frontend/src/modules/shared/presentation/ui/BackButton.tsx
+++ b/apps/frontend/src/modules/shared/presentation/ui/BackButton.tsx
@@ -1,0 +1,32 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { Button } from '@shadcn';
+import { ArrowLeft } from 'lucide-react';
+
+type BackButtonProps = Omit<ComponentProps<typeof Button>, 'className'> & {
+  label?: ReactNode;
+  iconOnly?: boolean;
+  className?: string;
+};
+
+export const BackButton = ({
+  label = 'Back',
+  iconOnly = false,
+  className = '',
+  ...props
+}: BackButtonProps) => {
+  const buttonClassName = iconOnly
+    ? `h-8 w-8 ${className}`.trim()
+    : `flex items-center gap-2 ${className}`.trim();
+
+  return (
+    <Button
+      {...props}
+      variant={props.variant ?? 'ghost'}
+      size={iconOnly ? 'icon' : props.size}
+      className={buttonClassName}
+    >
+      <ArrowLeft className='size-4' />
+      {!iconOnly && label}
+    </Button>
+  );
+};

--- a/apps/frontend/src/modules/shared/presentation/ui/index.ts
+++ b/apps/frontend/src/modules/shared/presentation/ui/index.ts
@@ -3,4 +3,5 @@ export * from './ListCard.tsx';
 export * from './status-indicator';
 export * from './DataTable.tsx';
 export * from './FeatureHeader.tsx';
+export * from './BackButton.tsx';
 export * from './FormDialog.tsx';


### PR DESCRIPTION
## Summary
- Merges `fix/frontend/breadcrumbs-emphasis` into front-end
- Merges `feat/frontend/back-buttons` into front-end
- Conflict resolutions: kept `PipelineMetadata` typing, unified `goToJobs(PipelineIdentity)`, retained `onBack` from back-buttons branch

## Test plan
- [ ] Pipeline dashboard loads, back button works
- [ ] View jobs from pipeline action navigates correctly with breadcrumb context
- [ ] Edit pipeline still works

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->