### PR TITLE
Front end

### DIFF
--- a/apps/frontend/lingui.config.js
+++ b/apps/frontend/lingui.config.js
@@ -33,6 +33,10 @@ export default defineConfig({
       include: ['src/modules/features/organization/'],
     },
     {
+      path: '<rootDir>/src/modules/features/workers/locales/{locale}/messages',
+      include: ['src/modules/features/workers/'],
+    },
+    {
       path: '<rootDir>/src/locales/{locale}/messages',
       include: ['src/modules/shared/', 'src/modules/layout/', 'src/modules/core/'],
     },

--- a/apps/frontend/src/locales/en/messages.po
+++ b/apps/frontend/src/locales/en/messages.po
@@ -22,7 +22,7 @@ msgstr "{0}"
 msgid "An error occurred"
 msgstr "An error occurred"
 
-#: src/modules/core/presentation/ui/App.tsx:49
+#: src/modules/core/presentation/ui/App.tsx:51
 msgid "An unexpected error occurred"
 msgstr "An unexpected error occurred"
 
@@ -71,7 +71,7 @@ msgstr "Log out"
 msgid "New {label}"
 msgstr "New {label}"
 
-#: src/modules/core/presentation/ui/App.tsx:66
+#: src/modules/core/presentation/ui/App.tsx:68
 msgid "Operation failed"
 msgstr "Operation failed"
 
@@ -84,8 +84,8 @@ msgstr "Organization"
 msgid "Select Organization"
 msgstr "Select Organization"
 
-#: src/modules/core/presentation/ui/App.tsx:48
-#: src/modules/core/presentation/ui/App.tsx:65
+#: src/modules/core/presentation/ui/App.tsx:50
+#: src/modules/core/presentation/ui/App.tsx:67
 msgid "Server unreachable"
 msgstr "Server unreachable"
 

--- a/apps/frontend/src/locales/fr/messages.po
+++ b/apps/frontend/src/locales/fr/messages.po
@@ -22,7 +22,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr "Une erreur est survenue"
 
-#: src/modules/core/presentation/ui/App.tsx:49
+#: src/modules/core/presentation/ui/App.tsx:51
 msgid "An unexpected error occurred"
 msgstr "Une erreur inattendue est survenue"
 
@@ -71,7 +71,7 @@ msgstr "Se déconnecter"
 msgid "New {label}"
 msgstr ""
 
-#: src/modules/core/presentation/ui/App.tsx:66
+#: src/modules/core/presentation/ui/App.tsx:68
 msgid "Operation failed"
 msgstr "L'opération a échoué"
 
@@ -84,8 +84,8 @@ msgstr "Organisation"
 msgid "Select Organization"
 msgstr "Sélectionner une organisation"
 
-#: src/modules/core/presentation/ui/App.tsx:48
-#: src/modules/core/presentation/ui/App.tsx:65
+#: src/modules/core/presentation/ui/App.tsx:50
+#: src/modules/core/presentation/ui/App.tsx:67
 msgid "Server unreachable"
 msgstr "Serveur inaccessible"
 

--- a/apps/frontend/src/modules/core/presentation/ui/App.tsx
+++ b/apps/frontend/src/modules/core/presentation/ui/App.tsx
@@ -14,6 +14,7 @@ import { messages as organizationMessages } from '@/modules/features/organizatio
 import { messages as userMessages } from '@/modules/features/user/locales/en/messages.ts';
 import { messages as sharedMessages } from '@/locales/en/messages.ts';
 import { messages as jobMessages } from '@/modules/features/jobs/locales/en/messages.ts';
+import { messages as workersMessages } from '@/modules/features/workers/locales/en/messages.ts';
 
 import { ScyllaError } from '@shared/utils/scylla-result.ts';
 import { toast } from '@shared/presentation/utils/toast.ts';
@@ -28,6 +29,7 @@ i18n.load('en', {
   ...organizationMessages,
   ...sharedMessages,
   ...jobMessages,
+  ...workersMessages,
 });
 i18n.activate('en');
 

--- a/apps/frontend/src/modules/features/workers/locales/en/messages.po
+++ b/apps/frontend/src/modules/features/workers/locales/en/messages.po
@@ -1,0 +1,104 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-05-02 12:56+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+
+#. placeholder {0}: filteredWorkers.length
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:107
+msgid "{0} workers found"
+msgstr "{0} workers found"
+
+#: src/modules/features/workers/presentation/ui/workers-table/WorkerColumns.tsx:73
+msgid "Actions"
+msgstr "Actions"
+
+#: src/modules/features/workers/presentation/ui/workers-table/WorkerColumns.tsx:35
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:197
+msgid "Agent ID"
+msgstr "Agent ID"
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:46
+msgid "Agent ID:"
+msgstr "Agent ID:"
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:29
+msgid "Back"
+msgstr "Back"
+
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:110
+msgid "Click a worker to view details."
+msgstr "Click a worker to view details."
+
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:214
+msgid "Created at"
+msgstr "Created at"
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:64
+msgid "Created at:"
+msgstr "Created at:"
+
+#: src/modules/features/workers/presentation/ui/workers-table/WorkerColumns.tsx:26
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:179
+msgid "Hostname"
+msgstr "Hostname"
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:40
+msgid "Hostname:"
+msgstr "Hostname:"
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:26
+msgid "Information about the selected worker."
+msgstr "Information about the selected worker."
+
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:203
+msgid "Last seen"
+msgstr "Last seen"
+
+#: src/modules/features/workers/presentation/ui/workers-table/WorkerColumns.tsx:60
+msgid "Last Seen"
+msgstr "Last Seen"
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:58
+msgid "Last seen at:"
+msgstr "Last seen at:"
+
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:145
+msgid "Last seen:"
+msgstr "Last seen:"
+
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:171
+msgid "No worker selected."
+msgstr "No worker selected."
+
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:164
+msgid "Select a worker from the list to view its full information."
+msgstr "Select a worker from the list to view its full information."
+
+#: src/modules/features/workers/presentation/ui/workers-table/WorkerColumns.tsx:49
+msgid "Status"
+msgstr "Status"
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:52
+msgid "Status:"
+msgstr "Status:"
+
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:222
+msgid "Updated at"
+msgstr "Updated at"
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:70
+msgid "Updated at:"
+msgstr "Updated at:"
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:35
+msgid "Worker"
+msgstr "Worker"
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:23
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:161
+msgid "Worker details"
+msgstr "Worker details"

--- a/apps/frontend/src/modules/features/workers/locales/fr/messages.po
+++ b/apps/frontend/src/modules/features/workers/locales/fr/messages.po
@@ -1,0 +1,104 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-05-02 12:56+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: fr\n"
+
+#. placeholder {0}: filteredWorkers.length
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:107
+msgid "{0} workers found"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/workers-table/WorkerColumns.tsx:73
+msgid "Actions"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/workers-table/WorkerColumns.tsx:35
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:197
+msgid "Agent ID"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:46
+msgid "Agent ID:"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:29
+msgid "Back"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:110
+msgid "Click a worker to view details."
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:214
+msgid "Created at"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:64
+msgid "Created at:"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/workers-table/WorkerColumns.tsx:26
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:179
+msgid "Hostname"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:40
+msgid "Hostname:"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:26
+msgid "Information about the selected worker."
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:203
+msgid "Last seen"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/workers-table/WorkerColumns.tsx:60
+msgid "Last Seen"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:58
+msgid "Last seen at:"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:145
+msgid "Last seen:"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:171
+msgid "No worker selected."
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:164
+msgid "Select a worker from the list to view its full information."
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/workers-table/WorkerColumns.tsx:49
+msgid "Status"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:52
+msgid "Status:"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:222
+msgid "Updated at"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:70
+msgid "Updated at:"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:35
+msgid "Worker"
+msgstr ""
+
+#: src/modules/features/workers/presentation/ui/WorkerDetails.page.tsx:23
+#: src/modules/features/workers/presentation/ui/Workers.page.tsx:161
+msgid "Worker details"
+msgstr ""


### PR DESCRIPTION
This pull request adds i18n (internationalization) support for the "workers" feature module in both English and French. It updates the Lingui configuration and message loading logic to include the new translations, and introduces English and French `.po` files for worker-related UI strings. Additionally, it updates references in the main translation files to reflect recent changes in the codebase.

**i18n support for workers module:**

* Added new English (`messages.po`) and French (`messages.po`) translation files for the `workers` feature, containing all relevant UI strings for worker management. [[1]](diffhunk://#diff-1e790eee3366017bd42f23e4ad142b00e535bd24a0429f7b7ce1075317d963caR1-R104) [[2]](diffhunk://#diff-15edfa62a0e379fe34fdfdaf96d1569d908fbd62f45cf6b20616580d68693a4dR1-R104)
* Updated Lingui configuration in `lingui.config.js` to include the `workers` module for translation extraction.
* Modified the main app to import and load the `workers` translations alongside other modules in `App.tsx`. [[1]](diffhunk://#diff-9f70d7d3f7c6d685a3de71282239d19beb154c43f9f96b4cc96a56c48930272bR17) [[2]](diffhunk://#diff-9f70d7d3f7c6d685a3de71282239d19beb154c43f9f96b4cc96a56c48930272bR32)

**Translation and reference updates:**

* Updated English (`en/messages.po`) and French (`fr/messages.po`) main translation files to reflect new line numbers for error and status messages in `App.tsx`, ensuring correct mapping after recent code changes. [[1]](diffhunk://#diff-694e430b33924624f020ff852cc721500906cebbf65fa77b32558324085aa9f6L25-R25) [[2]](diffhunk://#diff-694e430b33924624f020ff852cc721500906cebbf65fa77b32558324085aa9f6L74-R74) [[3]](diffhunk://#diff-694e430b33924624f020ff852cc721500906cebbf65fa77b32558324085aa9f6L87-R88) [[4]](diffhunk://#diff-505ac8f7d39e074e0ac6bdb97c47cdc63de75556684199b550460654a6b31524L25-R25) [[5]](diffhunk://#diff-505ac8f7d39e074e0ac6bdb97c47cdc63de75556684199b550460654a6b31524L74-R74) [[6]](diffhunk://#diff-505ac8f7d39e074e0ac6bdb97c47cdc63de75556684199b550460654a6b31524L87-R88)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->