### PR TITLE
refacto(frontend): job log in stream only if its not log of a node bu…

### DIFF
--- a/apps/frontend/src/modules/features/jobs/presentation/hooks/use-job-logs.ts
+++ b/apps/frontend/src/modules/features/jobs/presentation/hooks/use-job-logs.ts
@@ -4,7 +4,7 @@ import type { JobLog } from '@/modules/features/jobs/domain/models/job.model.ts'
 import type { PaginatedList } from '@shared/domain/types/paginated-list.type.ts';
 import type { ScyllaError } from '@shared/utils/scylla-result.ts';
 
-export const useJobLogs = (jobId: string) => {
+export const useJobLogs = (jobId: string, nodeId?: string) => {
   const { listJobLogs } = useDependencies().jobs;
 
   const {
@@ -13,7 +13,7 @@ export const useJobLogs = (jobId: string) => {
     isError,
   } = useQuery<PaginatedList<JobLog>, ScyllaError>({
     queryKey: ['job-logs'],
-    queryFn: async () => (await listJobLogs.execute(jobId)).unwrap(),
+    queryFn: async () => (await listJobLogs.execute(jobId, nodeId)).unwrap(),
     staleTime: 1000 * 3,
   });
 

--- a/apps/frontend/src/modules/features/jobs/presentation/ui/jobs-table/jobs-log/JobLogDisplay.tsx
+++ b/apps/frontend/src/modules/features/jobs/presentation/ui/jobs-table/jobs-log/JobLogDisplay.tsx
@@ -3,15 +3,21 @@ import { StreamLanguage } from '@codemirror/language';
 import { shell } from '@codemirror/legacy-modes/mode/shell';
 import { codeMirrorTheme } from '@/modules/features/pipeline/presentation/utils/code-mirror-theme.ts';
 import { useTailJobLogs } from '@/modules/features/jobs/presentation/hooks/use-tail-job-logs.ts';
+import { useJobLogs } from '@/modules/features/jobs/presentation/hooks/use-job-logs.ts';
+import { useMemo } from 'react';
 
 interface JobLogDisplayProps {
   jobId: string;
   nodeId?: string;
 }
 
-export const JobLogDisplay = ({ jobId, nodeId }: JobLogDisplayProps) => {
-  const { logString, isError, isLoading } = useTailJobLogs(jobId, nodeId);
+interface LogViewerProps {
+  logs: string;
+  isLoading: boolean;
+  isError: boolean;
+}
 
+const LogViewer = ({ logs, isLoading, isError }: LogViewerProps) => {
   if (isLoading) return <div>Loading...</div>;
   if (isError) return <div>Error loading logs...</div>;
 
@@ -21,10 +27,35 @@ export const JobLogDisplay = ({ jobId, nodeId }: JobLogDisplayProps) => {
         readOnly
         editable={false}
         autoFocus={false}
-        value={logString}
+        value={logs}
         maxHeight={'15rem'}
         extensions={[StreamLanguage.define(shell), codeMirrorTheme]}
       />
     </div>
   );
+};
+
+const StreamingJobLogs = ({ jobId }: { jobId: string }) => {
+  const { logString, isLoading, isError } = useTailJobLogs(jobId);
+
+  return <LogViewer logs={logString} isLoading={isLoading} isError={isError} />;
+};
+
+const FetchedJobLogs = ({ jobId, nodeId }: { jobId: string; nodeId: string }) => {
+  const { logs, isLoading, isError } = useJobLogs(jobId, nodeId);
+
+  const formattedLogs = useMemo(
+    () => logs?.items.map(log => log.line).join('\n') ?? '',
+    [logs],
+  );
+
+  return <LogViewer logs={formattedLogs} isLoading={isLoading} isError={isError} />;
+};
+
+export const JobLogDisplay = ({ jobId, nodeId }: JobLogDisplayProps) => {
+  if (nodeId) {
+    return <FetchedJobLogs jobId={jobId} nodeId={nodeId} />;
+  }
+
+  return <StreamingJobLogs jobId={jobId} />;
 };


### PR DESCRIPTION
…t log of the full job

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->