### PR TITLE
docs: Docker-first README + multi-arch image note + just pull/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,87 +6,99 @@ Distributed CI/CD platform.
 
 | Service          | Port    | Description                                  |
 |------------------|---------|----------------------------------------------|
+| `scylla-frontend`| `8080`  | Web UI (Caddy-served static build)           |
 | `scylla-api`     | `50051` | gRPC API (auth, projects, pipelines, jobs)   |
 | `scylla-broker`  | `50052` | Broker for job dispatch and agent presence   |
 | `scylla-agent`   | —       | Worker that runs pipeline jobs               |
 | `scylla-recorder`| —       | Persists broker events into SurrealDB        |
 | `surrealdb`      | `8000`  | Primary datastore                            |
-| `frontend`       | `5173`  | Vite dev server                              |
 
 ## Prerequisites
 
-Install before starting:
+You only need Docker. Everything else (Rust, Node.js, pnpm) runs inside containers.
 
 - **Docker** (>= 24) with **Docker Compose** v2
-- **Node.js** >= 20 and **pnpm** >= 9 (enable via `corepack enable`)
-- **[just](https://github.com/casey/just)** (**optional**, shortcuts for docker compose)
-- **Rust** toolchain (**optional**, only to build crates outside Docker)
+- **[just](https://github.com/casey/just)** (optional, shortcuts for `docker compose`)
 
 Check versions:
 
 ```sh
 docker --version
 docker compose version
-node --version
-pnpm --version
 ```
 
-## 1. Clone
+## Quick start
+
+Prebuilt images are published for both `linux/amd64` and `linux/arm64` — Docker pulls the right one for your host automatically.
+
+One command pulls the prebuilt images and starts the full stack (API, broker, agent, recorder, SurrealDB, frontend):
 
 ```sh
 git clone https://github.com/scylla-ops/scylla.git
 cd scylla
-```
-
-## 2. Start everything
-
-Pulls prebuilt images and starts all backend services (API, broker, agent, recorder, SurrealDB).
-
-```sh
-docker compose up -d
-# or
 just up
+# or, without just:
+docker compose pull && docker compose up -d
 ```
 
 First boot creates the `admin` user automatically.
 
-**Default credentials:**
+Open **http://localhost:8080/** and sign in:
 
 - username: `admin`
 - password: `admin123`
 
-Your app is now ready at: http://localhost:8080/
+## Common commands
 
-## 4. Stop everything
+| `just`        | `docker compose`                  | What it does                                  |
+|---------------|-----------------------------------|-----------------------------------------------|
+| `just up`     | `docker compose pull && up -d`    | Pull latest images and start the stack        |
+| `just pull`   | `docker compose pull`             | Refresh images without (re)starting           |
+| `just update` | `docker compose pull && up -d`    | Pull and recreate containers on a running stack |
+| `just down`   | `docker compose down`             | Stop the stack                                |
+| `just clean`  | `docker compose down -v --rmi local --remove-orphans` | Stop and wipe volumes + local images |
+| `just logs [svc]` | `docker compose logs -f [svc]` | Follow logs (all services or one)            |
+| `just status` | `docker compose ps`               | Show running containers                       |
 
-```sh
-docker compose down
-# or
-just down
-```
-
-To also wipe the database volume:
-
-```sh
-docker compose down -v
-# or
-just clean
-```
+Run `just --list` to see every recipe.
 
 ## Troubleshooting
 
-**Port already in use.** Another process holds `5173`, `8000`, `50051`, or `50052`. Stop it or change the host port in `docker-compose.yaml`.
+**Port already in use.** Another process holds `8080`, `8000`, `50051`, or `50052`. Stop it or change the host port in `docker-compose.yaml`.
 
-**`scylla-api` fails to connect to SurrealDB.** Ensure `surrealdb` is `healthy` via `docker compose ps`. If it's stuck, run `docker compose down -v` to reset the volume and try again.
+**`scylla-api` fails to connect to SurrealDB.** Ensure `surrealdb` is `healthy` via `just status` (or `docker compose ps`). If it's stuck, run `just clean` to reset the volume and try again.
 
-**Frontend shows gRPC errors.** Verify `scylla-api` is reachable on `http://localhost:50051`. Browser must accept CORS, default config already allows `http://localhost:5173`.
+**Frontend shows gRPC errors.** Verify the UI on `http://localhost:8080` can reach `scylla-api` on `http://localhost:50051`. The browser must accept CORS — the default config already allows `http://localhost:8080`.
 
-**Agent not picking up jobs.** Check `docker compose logs -f scylla-agent` and confirm the broker URL resolves. Restart with `docker compose restart scylla-agent`.
+**Agent not picking up jobs.** Check `just logs scylla-agent` and confirm the broker URL resolves. Restart with `docker compose restart scylla-agent`.
 
-> Still stuck? Reach us by openning a post in the `help` Discord channel with:
-  >- steps to reproduce
-  >- `docker compose logs` output for the affected service
-  >- `docker compose ps` snapshot
+> Still stuck? Open a post in the `help` Discord channel with:
+>  - steps to reproduce
+>  - `docker compose logs` output for the affected service
+>  - `docker compose ps` snapshot
+
+## Optional: local development
+
+The Docker workflow above is self-contained — **Node.js and Rust are not required** to run Scylla. The sections below are only for contributors who want to iterate on the frontend or crates outside Docker.
+
+### Frontend (Vite dev server on `:5173`)
+
+Requires Node.js >= 20 and pnpm >= 9 (`corepack enable`). See [apps/frontend/README.md](apps/frontend/README.md) for setup.
+
+### Building crates locally
+
+Requires the Rust toolchain. Standard Cargo workflow:
+
+```sh
+cargo build
+cargo test
+```
+
+To build the Docker images from source instead of pulling them:
+
+```sh
+just local
+```
 
 ## Further reading
 

--- a/justfile
+++ b/justfile
@@ -24,11 +24,25 @@ default:
 local:
     docker compose build
 
-# Start all services
+# Start all services (pulls latest images, runs detached)
 [group('dev')]
 [no-exit-message]
 up:
-    docker compose up
+    docker compose pull
+    docker compose up -d
+
+# Pull latest images without (re)starting containers
+[group('dev')]
+[no-exit-message]
+pull:
+    docker compose pull
+
+# Refresh a running stack: pull latest images and recreate containers
+[group('dev')]
+[no-exit-message]
+update:
+    docker compose pull
+    docker compose up -d
 
 # Stop all services
 [group('dev')]


### PR DESCRIPTION
## Summary
- Rewrites `README.md` around a single-command Docker workflow. Node.js / Rust / pnpm move to an explicit \"Optional: local development\" section — they are not required to run Scylla.
- Fixes the architecture table (frontend is `:8080`, Caddy-served — `:5173` Vite is dev-only now).
- Adds a note that prebuilt images are published for both \`linux/amd64\` and \`linux/arm64\` so Docker picks the right one automatically.
- \`justfile\`: \`just up\` now runs \`docker compose pull && docker compose up -d\`. New \`just pull\` (refresh images) and \`just update\` (pull + recreate) recipes.

## Test plan
- [ ] \`just --list\` shows \`pull\` and \`update\` in the \`dev\` group
- [ ] After images are pushed to \`godlyjaaaaj/scylla-*:latest\`, \`just up\` brings the full stack up and \`http://localhost:8080\` loads the UI
- [ ] \`just update\` is idempotent on a running stack
- [ ] \`just down\` / \`just clean\` still behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->