### PR TITLE
ci: build and promote scylla-frontend image

### DIFF
--- a/.github/workflows/frontend-image.yaml
+++ b/.github/workflows/frontend-image.yaml
@@ -1,0 +1,211 @@
+## Build & promote the frontend Docker image on Blacksmith runners.
+##
+## - push to `front-end`  -> per-platform native build (amd64 + arm64) of the
+##                            scylla-frontend image, push by-digest, then merge
+##                            manifest publishes :front-end + :front-end-<sha7>.
+## - push to `dev`        -> retag (no rebuild) the front-end image at the merge
+##                            source SHA as :dev + :dev-<sha7>, falling back to the
+##                            floating :front-end tag if the per-SHA image is missing.
+## - push to `main`       -> retag the dev image at the merge source SHA as
+##                            :latest + :main-<sha7>, with fallback to :dev.
+##
+## Promotion expects PR merge commits (HEAD^2 = source branch tip).
+## Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN.
+
+name: Frontend image
+
+on:
+  push:
+    branches: [front-end, dev, main]
+
+env:
+  IMAGE_PREFIX: godlyjaaaaj
+  SERVICE: scylla-frontend
+  VITE_API_URL: http://localhost:50051
+
+jobs:
+  detect-changes:
+    name: Detect frontend changes
+    if: github.ref == 'refs/heads/front-end'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      changed: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            frontend:
+              - 'apps/frontend/**'
+              - 'crates/scylla-protocol/proto/**'
+              - '.github/workflows/frontend-image.yaml'
+
+  build:
+    name: Build scylla-frontend (${{ matrix.platform.arch }})
+    needs: detect-changes
+    if: github.ref == 'refs/heads/front-end' && needs.detect-changes.outputs.changed == 'true'
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { arch: amd64, runner: blacksmith-4vcpu-ubuntu-2404,     docker: linux/amd64 }
+          - { arch: arm64, runner: blacksmith-4vcpu-ubuntu-2404-arm, docker: linux/arm64 }
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: useblacksmith/setup-docker-builder@v1
+
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - id: build
+        uses: useblacksmith/build-push-action@v2
+        with:
+          context: .
+          file: apps/frontend/Dockerfile
+          platforms: ${{ matrix.platform.docker }}
+          push: true
+          provenance: false
+          build-args: |
+            VITE_API_URL=${{ env.VITE_API_URL }}
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ env.SERVICE }},push-by-digest=true,name-canonical=true
+          cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ env.SERVICE }}:buildcache-${{ matrix.platform.arch }}
+          cache-to: type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ env.SERVICE }}:buildcache-${{ matrix.platform.arch }},mode=max,image-manifest=true,oci-mediatypes=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest='${{ steps.build.outputs.digest }}'
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ env.SERVICE }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Publish scylla-frontend manifest
+    needs: [detect-changes, build]
+    if: github.ref == 'refs/heads/front-end' && needs.detect-changes.outputs.changed == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ env.SERVICE }}-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create manifest list
+        working-directory: /tmp/digests
+        run: |
+          refs=()
+          for f in *; do
+            refs+=("${{ env.IMAGE_PREFIX }}/${{ env.SERVICE }}@sha256:${f}")
+          done
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_PREFIX }}/${{ env.SERVICE }}:front-end \
+            -t ${{ env.IMAGE_PREFIX }}/${{ env.SERVICE }}:front-end-${{ steps.sha.outputs.short }} \
+            "${refs[@]}"
+
+  promote-dev:
+    name: Promote scylla-frontend to dev
+    if: github.ref == 'refs/heads/dev'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: refs
+        run: |
+          if ! SOURCE_FULL=$(git rev-parse HEAD^2 2>/dev/null); then
+            echo "::error::HEAD on dev is not a merge commit. Promotion expects a PR merge commit."
+            exit 1
+          fi
+          echo "source=${SOURCE_FULL::7}" >> "$GITHUB_OUTPUT"
+          echo "current=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Retag front-end -> dev
+        run: |
+          src_sha="${{ env.IMAGE_PREFIX }}/${{ env.SERVICE }}:front-end-${{ steps.refs.outputs.source }}"
+          src_tip="${{ env.IMAGE_PREFIX }}/${{ env.SERVICE }}:front-end"
+          if docker buildx imagetools inspect "$src_sha" >/dev/null 2>&1; then
+            src="$src_sha"
+          elif docker buildx imagetools inspect "$src_tip" >/dev/null 2>&1; then
+            echo "::notice::No image at $src_sha (non front-end merge?). Carrying forward $src_tip."
+            src="$src_tip"
+          else
+            echo "::error::Neither $src_sha nor $src_tip exists. Push front-end first so an image gets built."
+            exit 1
+          fi
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_PREFIX }}/${{ env.SERVICE }}:dev \
+            -t ${{ env.IMAGE_PREFIX }}/${{ env.SERVICE }}:dev-${{ steps.refs.outputs.current }} \
+            "$src"
+
+  promote-main:
+    name: Promote scylla-frontend to main
+    if: github.ref == 'refs/heads/main'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: refs
+        run: |
+          if ! SOURCE_FULL=$(git rev-parse HEAD^2 2>/dev/null); then
+            echo "::error::HEAD on main is not a merge commit. Promotion expects a PR merge commit from dev."
+            exit 1
+          fi
+          echo "source=${SOURCE_FULL::7}" >> "$GITHUB_OUTPUT"
+          echo "current=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Retag dev -> main
+        run: |
+          src_sha="${{ env.IMAGE_PREFIX }}/${{ env.SERVICE }}:dev-${{ steps.refs.outputs.source }}"
+          src_tip="${{ env.IMAGE_PREFIX }}/${{ env.SERVICE }}:dev"
+          if docker buildx imagetools inspect "$src_sha" >/dev/null 2>&1; then
+            src="$src_sha"
+          elif docker buildx imagetools inspect "$src_tip" >/dev/null 2>&1; then
+            echo "::notice::No image at $src_sha. Carrying forward $src_tip."
+            src="$src_tip"
+          else
+            echo "::error::Neither $src_sha nor $src_tip exists. Promote to dev first."
+            exit 1
+          fi
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_PREFIX }}/${{ env.SERVICE }}:latest \
+            -t ${{ env.IMAGE_PREFIX }}/${{ env.SERVICE }}:main-${{ steps.refs.outputs.current }} \
+            "$src"


### PR DESCRIPTION
## Summary
Adds \`.github/workflows/frontend-image.yaml\`, mirroring the structure of \`backend-images.yaml\`:

- Push to \`front-end\` → native multi-arch build (amd64 + arm64) → publishes \`godlyjaaaaj/scylla-frontend:front-end\` + \`:front-end-<sha7>\`.
- Push to \`dev\` → retag from \`:front-end-<source>\` (with fallback to floating \`:front-end\`) → \`:dev\` + \`:dev-<sha7>\`.
- Push to \`main\` → retag from \`:dev-<source>\` (with fallback to floating \`:dev\`) → \`:latest\` + \`:main-<sha7>\`.

Closes the gap left by the Docker-first README rewrite: the compose stack expects \`scylla-frontend:latest\` on Docker Hub, but until now nothing in CI produced it.

\`VITE_API_URL\` is baked at build time to \`http://localhost:50051\` (matching the docker-compose default), so a fresh \`just up\` works without a local image build.

## Test plan
- [ ] On merge, the workflow detects the new \`.github/workflows/frontend-image.yaml\` (in the paths-filter), runs \`build\` on both archs, and \`merge\` tags \`godlyjaaaaj/scylla-frontend:front-end\` + \`front-end-<sha7>\`.
- [ ] \`docker buildx imagetools inspect godlyjaaaaj/scylla-frontend:front-end\` shows both linux/amd64 and linux/arm64 manifests.
- [ ] A subsequent merge \`front-end → dev\` produces \`:dev\` / \`:dev-<sha7>\`.
- [ ] \`dev → main\` produces \`:latest\` / \`:main-<sha7>\`.

## Known caveat
\`VITE_API_URL\` is baked at build time. Deployments behind a reverse proxy or with a non-default API host need a local rebuild for now. Out of scope here; revisit when a runtime config mechanism exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->