### PR TITLE
fix(frontend): Dockerfile must copy pnpm-workspace.yaml before install

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -9,11 +9,11 @@ ENV PNPM_HOME=/pnpm \
 
 WORKDIR /app
 
-COPY apps/frontend/package.json apps/frontend/pnpm-lock.yaml ./
+COPY apps/frontend/package.json apps/frontend/pnpm-lock.yaml apps/frontend/pnpm-workspace.yaml ./
 
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
     pnpm config set store-dir /pnpm/store && \
-    pnpm install --no-frozen-lockfile
+    pnpm install --frozen-lockfile
 
 COPY crates/scylla-protocol/proto/ ../../crates/scylla-protocol/proto/
 COPY apps/frontend/ .


### PR DESCRIPTION
## Summary
Fixes the \`ERR_PNPM_IGNORED_BUILDS\` failure on the [latest Frontend image run](https://github.com/scylla-ops/scylla/actions/runs/25987060316).

**Root cause.** The Dockerfile copies only \`package.json\` + \`pnpm-lock.yaml\` before \`pnpm install\`. The build-script allowlist now lives in \`apps/frontend/pnpm-workspace.yaml\` (\`allowBuilds\`, since the pnpm 11 migration in #92), but that file wasn't being copied into the build context at install time — so pnpm fell back to its default \"refuse to run postinstalls\" behavior and exited with code 1.

**Fix.**
- Add \`pnpm-workspace.yaml\` to the COPY layer before install.
- Switch \`--no-frozen-lockfile\` → \`--frozen-lockfile\`. The lockfile is now in sync with package.json (just regenerated by pnpm 11 locally), so CI should refuse to silently re-resolve. Future lockfile drift will fail loudly instead of slipping in new transitive versions.

## Test plan
- [ ] On merge to \`front-end\`, the Frontend image workflow gets past \`pnpm install\` cleanly and produces \`scylla-frontend:front-end\` + \`:front-end-<sha7>\` for amd64 and arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->