### PR TITLE
fix(frontend/blueprint): step node editor should be scrollable

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/Scylla_Beta_Log.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Scylla Beta 0.1</title>
+    <title>Scylla Beta 0.2</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "my-app",
+  "name": "scylla",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.2.0",
   "type": "module",
   "packageManager": "pnpm@11.1.2",
   "scripts": {

--- a/apps/frontend/src/modules/features/pipeline/locales/en/messages.po
+++ b/apps/frontend/src/modules/features/pipeline/locales/en/messages.po
@@ -27,20 +27,20 @@ msgstr "Actions"
 msgid "Add a new node"
 msgstr "Add a new node"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:272
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:273
 msgid "Add argument"
 msgstr "Add argument"
 
 #: src/modules/features/pipeline/presentation/ui/editor/blueprint/BlueprintToolbar.tsx:14
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:381
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:382
 msgid "Add Node"
 msgstr "Add Node"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:370
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:371
 msgid "Add variable"
 msgstr "Add variable"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:250
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:251
 msgid "Arguments"
 msgstr "Arguments"
 
@@ -61,7 +61,7 @@ msgstr "Arguments"
 msgid "Blueprint"
 msgstr "Blueprint"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:378
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:379
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -70,7 +70,7 @@ msgstr "Cancel"
 #~ msgstr "Clear"
 
 #: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:198
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:239
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:240
 msgid "Command"
 msgstr "Command"
 
@@ -90,7 +90,7 @@ msgstr "Creation:"
 msgid "Define a new pipeline step. You can connect it to other nodes by dragging edges."
 msgstr "Define a new pipeline step. You can connect it to other nodes by dragging edges."
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:258
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:259
 msgid "e.g., --release"
 msgstr "e.g., --release"
 
@@ -102,7 +102,7 @@ msgstr "e.g., build"
 #~ msgid "e.g., build --release"
 #~ msgstr "e.g., build --release"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:245
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:246
 msgid "e.g., cargo"
 msgstr "e.g., cargo"
 
@@ -118,7 +118,7 @@ msgstr "Edit"
 msgid "Edit node"
 msgstr "Edit node"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:295
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:296
 msgid "Environment variables"
 msgstr "Environment variables"
 
@@ -133,7 +133,7 @@ msgstr "History"
 #~ msgid "in total"
 #~ msgstr "in total"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:303
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:304
 msgid "KEY"
 msgstr "KEY"
 
@@ -141,7 +141,7 @@ msgstr "KEY"
 msgid "Last Run"
 msgstr "Last Run"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:315
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:316
 msgid "Literal"
 msgstr "Literal"
 
@@ -192,11 +192,11 @@ msgstr "Pipeline name"
 #~ msgid "Pipeline Status"
 #~ msgstr "Pipeline Status"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:329
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:330
 msgid "Reference a secret"
 msgstr "Reference a secret"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:288
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:289
 msgid "relative to the job workspace"
 msgstr "relative to the job workspace"
 
@@ -206,7 +206,7 @@ msgid "Run"
 msgstr "Run"
 
 #: src/modules/features/pipeline/presentation/ui/editor/blueprint/StartNodeFormDialog.tsx:42
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:381
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:382
 msgid "Save"
 msgstr "Save"
 
@@ -219,11 +219,11 @@ msgstr "Script"
 msgid "Scripting"
 msgstr "Scripting"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:318
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:319
 msgid "Secret"
 msgstr "Secret"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:346
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:347
 msgid "secret name"
 msgstr "secret name"
 
@@ -235,7 +235,7 @@ msgstr "Select a project first"
 msgid "Set the name of the pipeline."
 msgstr "Set the name of the pipeline."
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:221
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:222
 msgid "Shell"
 msgstr "Shell"
 
@@ -248,7 +248,7 @@ msgstr "Status"
 #~ msgid "This feature will be available soon"
 #~ msgstr "This feature will be available soon"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:354
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:355
 msgid "value"
 msgstr "value"
 
@@ -256,6 +256,6 @@ msgstr "value"
 msgid "View Jobs"
 msgstr "View Jobs"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:282
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:283
 msgid "Working directory"
 msgstr "Working directory"

--- a/apps/frontend/src/modules/features/pipeline/locales/fr/messages.po
+++ b/apps/frontend/src/modules/features/pipeline/locales/fr/messages.po
@@ -27,20 +27,20 @@ msgstr ""
 msgid "Add a new node"
 msgstr ""
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:272
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:273
 msgid "Add argument"
 msgstr ""
 
 #: src/modules/features/pipeline/presentation/ui/editor/blueprint/BlueprintToolbar.tsx:14
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:381
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:382
 msgid "Add Node"
 msgstr ""
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:370
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:371
 msgid "Add variable"
 msgstr ""
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:250
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:251
 msgid "Arguments"
 msgstr ""
 
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Blueprint"
 msgstr ""
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:378
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:379
 msgid "Cancel"
 msgstr ""
 
@@ -70,7 +70,7 @@ msgstr ""
 #~ msgstr "Effacer"
 
 #: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:198
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:239
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:240
 msgid "Command"
 msgstr ""
 
@@ -90,7 +90,7 @@ msgstr "Création :"
 msgid "Define a new pipeline step. You can connect it to other nodes by dragging edges."
 msgstr ""
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:258
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:259
 msgid "e.g., --release"
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr ""
 #~ msgid "e.g., build --release"
 #~ msgstr ""
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:245
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:246
 msgid "e.g., cargo"
 msgstr ""
 
@@ -118,7 +118,7 @@ msgstr "Modifier"
 msgid "Edit node"
 msgstr ""
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:295
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:296
 msgid "Environment variables"
 msgstr ""
 
@@ -133,7 +133,7 @@ msgstr ""
 #~ msgid "in total"
 #~ msgstr "au total"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:303
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:304
 msgid "KEY"
 msgstr ""
 
@@ -141,7 +141,7 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:315
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:316
 msgid "Literal"
 msgstr ""
 
@@ -192,11 +192,11 @@ msgstr ""
 #~ msgid "Pipeline Status"
 #~ msgstr "État de la pipeline"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:329
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:330
 msgid "Reference a secret"
 msgstr ""
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:288
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:289
 msgid "relative to the job workspace"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgid "Run"
 msgstr "Exécuter"
 
 #: src/modules/features/pipeline/presentation/ui/editor/blueprint/StartNodeFormDialog.tsx:42
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:381
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:382
 msgid "Save"
 msgstr ""
 
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Scripting"
 msgstr ""
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:318
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:319
 msgid "Secret"
 msgstr ""
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:346
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:347
 msgid "secret name"
 msgstr ""
 
@@ -235,7 +235,7 @@ msgstr ""
 msgid "Set the name of the pipeline."
 msgstr ""
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:221
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:222
 msgid "Shell"
 msgstr ""
 
@@ -248,7 +248,7 @@ msgstr ""
 #~ msgid "This feature will be available soon"
 #~ msgstr "Cette fonctionnalité sera bientôt disponible"
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:354
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:355
 msgid "value"
 msgstr ""
 
@@ -256,6 +256,6 @@ msgstr ""
 msgid "View Jobs"
 msgstr ""
 
-#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:282
+#: src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx:283
 msgid "Working directory"
 msgstr ""

--- a/apps/frontend/src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx
+++ b/apps/frontend/src/modules/features/pipeline/presentation/ui/editor/blueprint/StepNodeFormDialog.tsx
@@ -207,14 +207,17 @@ export function StepNodeFormDialog({
                   <Trans>Script</Trans>
                 </Label>
 
-                <ReactCodeMirror
-                  id='node-script'
-                  value={script}
-                  onChange={value => setScript(value)}
-                  placeholder={'cd crates/api\ncargo build --release'}
-                  spellCheck={false}
-                  extensions={[StreamLanguage.define(shellLang), codeMirrorTheme]}
-                />
+                <div className={'h-full w-full overflow-auto p-2'}>
+                  <ReactCodeMirror
+                    id='node-script'
+                    className={'max-h-64 w-full'}
+                    value={script}
+                    onChange={value => setScript(value)}
+                    placeholder={'cd crates/api\ncargo build --release'}
+                    spellCheck={false}
+                    extensions={[StreamLanguage.define(shellLang), codeMirrorTheme]}
+                  />
+                </div>
               </div>
               <div className='space-y-2'>
                 <Label htmlFor='node-shell'>

--- a/apps/frontend/src/modules/shared/presentation/ui/DataTable.tsx
+++ b/apps/frontend/src/modules/shared/presentation/ui/DataTable.tsx
@@ -76,8 +76,8 @@ export function DataTable<TData, TValue>({
               className='hover:bg-transparent border-b border-slate-200'
             >
               {headerGroup.headers.map(header => {
-                const align = (header.column.columnDef.meta?.align ??
-                  (alignColumnsCenter ? 'center' : 'left'));
+                const align =
+                  header.column.columnDef.meta?.align ?? (alignColumnsCenter ? 'center' : 'left');
                 return (
                   <TableHead
                     key={header.id}
@@ -114,7 +114,7 @@ export function DataTable<TData, TValue>({
                     data-state={isSelected ? 'selected' : undefined}
                     onClick={() => onRowClick?.(row)}
                     className={cn(
-                      'border-b border-slate-100 transition-colors duration-150',
+                      'border-b [&>td:first-child]:border-l-[3px] border-slate-100 [&>td:first-child]:border-l-transparent transition-colors duration-150',
                       onRowClick && 'cursor-pointer',
                       onRowClick && !isSelected && 'hover:bg-slate-50',
                       isSelected &&
@@ -123,8 +123,8 @@ export function DataTable<TData, TValue>({
                   >
                     {row.getVisibleCells().map((cell, index) => {
                       const header = table.getHeaderGroups()[0].headers[index];
-                      const align = (cell.column.columnDef.meta?.align ??
-                        (alignRowsCenter ? 'center' : 'left'));
+                      const align =
+                        cell.column.columnDef.meta?.align ?? (alignRowsCenter ? 'center' : 'left');
                       return (
                         <TableCell
                           key={cell.id}


### PR DESCRIPTION
The alert should not scroll, only the editor after a certain height.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783694083&installation_id=127778291&pr_number=101&repository=scylla-ops%2Fscylla&return_to=https%3A%2F%2Fgithub.com%2Fscylla-ops%2Fscylla%2Fpull%2F101&signature=bb72eed9bd07cf33733c6e8f1a24bda3ddb17c36649731a1a1ae6cbab5e64b3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->