### PR TITLE
chore(just): up pulls the saas beta stack by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ One command pulls the prebuilt images and starts the stack (control plane, Postg
 ```sh
 git clone https://github.com/scylla-ops/scylla.git
 cd scylla
-just up-saas
+just up
 # or, without just:
 docker compose -f docker-compose.yaml -f docker-compose.saas.yaml pull
 docker compose -f docker-compose.yaml -f docker-compose.saas.yaml up -d
 ```
 
-The beta ships the SaaS (multi-tenant) edition — that's what `just up-saas`
-pulls. `just up` starts the single-tenant PaaS edition instead; its prebuilt
-images are refreshed less often during the beta.
+The beta ships the SaaS (multi-tenant) edition — that's what `just up`
+pulls. The single-tenant PaaS edition is still buildable (`just local`), but
+its prebuilt images are refreshed less often during the beta.
 
 First boot creates the `admin` user automatically.
 
@@ -60,8 +60,7 @@ Open **http://localhost:8080/** and sign in:
 
 | `just`        | `docker compose`                  | What it does                                  |
 |---------------|-----------------------------------|-----------------------------------------------|
-| `just up-saas` | same, with the two SaaS overlay `-f` files | Pull and start (or refresh) the SaaS beta stack |
-| `just up`     | `docker compose pull && up -d`    | Pull and start the single-tenant PaaS stack   |
+| `just up`     | `compose -f … -f …saas… pull && up -d` | Pull and start (or refresh) the beta stack |
 | `just down`   | `docker compose down`             | Stop the stack                                |
 | `just clean`  | `docker compose down -v --rmi local --remove-orphans` | Stop and wipe volumes + local images |
 | `just logs [svc]` | `docker compose logs -f [svc]` | Follow logs (all services or one)            |

--- a/docs/release.md
+++ b/docs/release.md
@@ -38,8 +38,8 @@ the SaaS beta. The agent and frontend images have no edition split — the same
 images serve both.
 
 Deployment consumes the same variables: the SaaS compose overlay points the
-control-plane at `:${VERSION:-latest}-saas`, so `just up-saas` (or
-`VERSION=0.3.0 just up-saas`) pulls exactly what the matching `just release`
+control-plane at `:${VERSION:-latest}-saas`, so `just up` (or
+`VERSION=0.3.0 just up`) pulls exactly what the matching `just release`
 pushed. The base compose alone stays on the PaaS `:latest` — refresh it with
 `just release-backend` when needed.
 

--- a/justfile
+++ b/justfile
@@ -44,17 +44,10 @@ start:
 start-saas:
     docker compose -f docker-compose.yaml -f docker-compose.saas.yaml up -d
 
-# Pull latest images and start the stack
+# Pull the released beta images (SaaS edition) and start the stack
 [group('dev')]
 [no-exit-message]
 up:
-    docker compose pull
-    docker compose up -d
-
-# Pull the released SaaS images and start the stack
-[group('dev')]
-[no-exit-message]
-up-saas:
     docker compose -f docker-compose.yaml -f docker-compose.saas.yaml pull
     docker compose -f docker-compose.yaml -f docker-compose.saas.yaml up -d
 


### PR DESCRIPTION
`just up` is now THE quickstart command: it pulls and starts the SaaS overlay (what the beta actually ships). `just up-saas` is gone, README quick start and commands table plus the release docs follow. The PaaS edition stays buildable via `just local` / startable via `just start`.
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783763103&installation_id=127778291&pr_number=104&repository=scylla-ops%2Fscylla&return_to=https%3A%2F%2Fgithub.com%2Fscylla-ops%2Fscylla%2Fpull%2F104&signature=aa108545d4efdafc69ea2dce099e28f654556b1cf5c319df746151b59d12bba9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
