### PR TITLE
fix(just): release-saas also tags latest-saas

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -53,7 +53,7 @@ frontend assets at build time, default `http://localhost:50051`), `BUILDER`
 | Recipe | Image | Tags |
 |---|---|---|
 | `release-backend` | `$DOCKER_USER/scylla-control-plane`, `…/scylla-agent` | `:$VERSION`, `:latest` |
-| `release-saas` | `$DOCKER_USER/scylla-control-plane` | `:$VERSION-saas`, `:saas` |
+| `release-saas` | `$DOCKER_USER/scylla-control-plane` | `:$VERSION-saas`, `:latest-saas`, `:saas` |
 | `release-frontend` | `$DOCKER_USER/scylla-frontend` | `:$VERSION`, `:latest` |
 
 ## Notes

--- a/justfile
+++ b/justfile
@@ -155,6 +155,7 @@ release-saas: _info
         --build-arg PACKAGE=scylla-control-plane \
         --build-arg FEATURES=saas \
         -t {{DOCKER_USER}}/scylla-control-plane:{{VERSION}}-saas \
+        -t {{DOCKER_USER}}/scylla-control-plane:latest-saas \
         -t {{DOCKER_USER}}/scylla-control-plane:saas \
         --push .
 


### PR DESCRIPTION
The SaaS compose overlay defaults to `:latest-saas`, but a versioned `just release` only pushed `:VERSION-saas` and `:saas` — quickstart testers (`just up` without VERSION) would stay pinned to the previous latest-saas forever. `release-saas` now pushes `:latest-saas` too, symmetric with the `:latest` tag of the agent/frontend images.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783763540&installation_id=127778291&pr_number=105&repository=scylla-ops%2Fscylla&return_to=https%3A%2F%2Fgithub.com%2Fscylla-ops%2Fscylla%2Fpull%2F105&signature=ac1d4aa91f527f00b2ea3e89d9774a522cb4b2238c4ea333e87040a1241cde0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->