### PR TITLE
fix(just): release-saas also tags latest-saas

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -53,7 +53,7 @@ frontend assets at build time, default `http://localhost:50051`), `BUILDER`
 | Recipe | Image | Tags |
 |---|---|---|
 | `release-backend` | `$DOCKER_USER/scylla-control-plane`, `…/scylla-agent` | `:$VERSION`, `:latest` |
-| `release-saas` | `$DOCKER_USER/scylla-control-plane` | `:$VERSION-saas`, `:saas` |
+| `release-saas` | `$DOCKER_USER/scylla-control-plane` | `:$VERSION-saas`, `:latest-saas`, `:saas` |
 | `release-frontend` | `$DOCKER_USER/scylla-frontend` | `:$VERSION`, `:latest` |
 
 ## Notes

--- a/justfile
+++ b/justfile
@@ -155,6 +155,7 @@ release-saas: _info
         --build-arg PACKAGE=scylla-control-plane \
         --build-arg FEATURES=saas \
         -t {{DOCKER_USER}}/scylla-control-plane:{{VERSION}}-saas \
+        -t {{DOCKER_USER}}/scylla-control-plane:latest-saas \
         -t {{DOCKER_USER}}/scylla-control-plane:saas \
         --push .
 


### PR DESCRIPTION
Carries #105 to main: `release-saas` now also pushes `:latest-saas`, so the SaaS compose overlay default (`:${VERSION:-latest}-saas`) keeps tracking the newest release after a versioned `just release`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783763565&installation_id=127778291&pr_number=106&repository=scylla-ops%2Fscylla&return_to=https%3A%2F%2Fgithub.com%2Fscylla-ops%2Fscylla%2Fpull%2F106&signature=fe409ca379d35c97e2b055fdccf4d1472236e0743637028f1ce1c885ff5a6e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->