### PR TITLE
fix(just): sqlx prepare recipes run with --all-features

### DIFF
--- a/justfile
+++ b/justfile
@@ -92,15 +92,17 @@ db-migrate:
 db-revert:
     DATABASE_URL={{DATABASE_URL}} cargo sqlx migrate revert --source migrations
 
-# Regenerate the offline query cache (commit the resulting .sqlx/ dir)
+# Regenerate the offline query cache (commit the resulting .sqlx/ dir).
+# --all-features so feature-gated queries (saas, invitations, oauth…) stay in
+# the cache — without it a regen would silently break the SaaS offline build.
 [group('db')]
 db-prepare:
-    DATABASE_URL={{DATABASE_URL}} cargo sqlx prepare --workspace -- --tests
+    DATABASE_URL={{DATABASE_URL}} cargo sqlx prepare --workspace -- --all-features --tests
 
 # Verify .sqlx/ is up-to-date
 [group('db')]
 db-prepare-check:
-    DATABASE_URL={{DATABASE_URL}} cargo sqlx prepare --workspace --check -- --tests
+    DATABASE_URL={{DATABASE_URL}} cargo sqlx prepare --workspace --check -- --all-features --tests
 
 # Drop & recreate the local Postgres dev volume (DESTRUCTIVE)
 [group('db')]


### PR DESCRIPTION
The committed `.sqlx` cache is generated with `--all-features`. The `db-prepare`/`db-prepare-check` recipes ran without it, so a regen would silently purge feature-gated queries (saas, invitations, oauth…) and break the offline SaaS Docker build — and the check warned about 'potentially unused queries'. Both recipes now pass `--all-features`; verified clean on a live check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scylla-ops/codesmith/scylla/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783763924&installation_id=127778291&pr_number=107&repository=scylla-ops%2Fscylla&return_to=https%3A%2F%2Fgithub.com%2Fscylla-ops%2Fscylla%2Fpull%2F107&signature=8de6dc6af116c13415e2b30c1dd4baeaadc2d92f897b982900322fe60b82e3bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->