### PR TITLE
feat(agent): TLS dial to https control plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,6 +2000,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2585,6 +2601,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,6 +2652,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2765,6 +2802,29 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3530,9 +3590,11 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "rustls-native-certs",
  "socket2",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/crates/scylla-agent/Cargo.toml
+++ b/crates/scylla-agent/Cargo.toml
@@ -13,8 +13,9 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 
-# grpc
-tonic = { workspace = true }
+# grpc — `tls-ring` + `tls-native-roots` so the agent can dial an https://
+# control-plane (TLS terminated at the proxy) using the host's trust store.
+tonic = { workspace = true, features = ["tls-ring", "tls-native-roots"] }
 
 # cli
 clap = { workspace = true, features = ["env"] }

--- a/crates/scylla-agent/src/agent.rs
+++ b/crates/scylla-agent/src/agent.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Streaming;
 use tonic::metadata::MetadataValue;
-use tonic::transport::Channel;
+use tonic::transport::{Channel, ClientTlsConfig};
 use tonic::{Code, Request};
 use tracing::{error, info, warn};
 
@@ -107,13 +107,19 @@ impl Agent {
     /// agent stream. Returns the inbound (server→agent) stream and the
     /// up-stream sender (agent→server).
     async fn connect(&self) -> Result<(Streaming<AgentDown>, mpsc::Sender<AgentUp>), AgentError> {
-        let channel = Channel::from_shared(self.config.control_plane_url.clone())
-            .map_err(|e| AgentError::InvalidUrl {
-                url: self.config.control_plane_url.clone(),
+        let url = self.config.control_plane_url.clone();
+        let mut endpoint =
+            Channel::from_shared(url.clone()).map_err(|e| AgentError::InvalidUrl {
+                url: url.clone(),
                 message: e.to_string(),
-            })?
-            .connect()
-            .await?;
+            })?;
+        // An https:// control plane terminates TLS at the proxy (which then
+        // speaks h2c to the backend); load the host's native roots so the
+        // handshake succeeds. Plain http:// (local dev) stays cleartext h2c.
+        if url.starts_with("https://") {
+            endpoint = endpoint.tls_config(ClientTlsConfig::new().with_native_roots())?;
+        }
+        let channel = endpoint.connect().await?;
 
         let token = AppAuthServiceClient::new(channel.clone())
             .issue_token(IssueTokenRequest {


### PR DESCRIPTION
L'agent charge le trust store natif de l'hôte et active TLS (tls-ring + tls-native-roots) quand l'URL du control plane est en https://. Le proxy termine le TLS puis parle h2c au backend. En http:// (dev local), la connexion reste en h2c cleartext.