### PR TITLE
fix(api): require RunPipeline to manually fire a trigger (IDOR) + authz audit

### DIFF
--- a/crates/scylla-api/src/grpc/handlers/trigger_handler.rs
+++ b/crates/scylla-api/src/grpc/handlers/trigger_handler.rs
@@ -23,7 +23,8 @@ use tonic::{Request, Response, Status};
 
 /// gRPC surface for managing a pipeline's triggers. CRUD is delegated to
 /// [`TriggerUseCases`] (Cedar-gated by `manageTriggers`, with the create/update
-/// anti-escalation `runPipeline` check); manual firing goes through
+/// anti-escalation `runPipeline` check); manual firing is authorized against the
+/// caller's `runPipeline` on the trigger's pipeline, then goes through
 /// [`TriggerFireUseCases`], which runs as the org's trigger-runner App. On create,
 /// a webhook trigger's generated signing secret is returned ONCE in
 /// `webhook_secret`; `webhook_url` in every view is built from the configured
@@ -212,14 +213,14 @@ where
         &self,
         request: Request<FireTriggerNowRequest>,
     ) -> Result<Response<JobResponse>, Status> {
-        let _caller = caller!(request);
+        let caller = caller!(request);
         let id = TriggerId::new(&required(request.into_inner().trigger_id, "trigger_id")?);
 
-        // Manual fire: no webhook payload, so only literal inputs apply. The fire
-        // is authorized as the org's runner App inside the use case.
+        // Manual fire is authorized inside the use case (`RunPipeline` on the
+        // trigger's pipeline), then runs as the org's trigger-runner App.
         let job = self
             .fire_uc
-            .fire(&id, None, None)
+            .fire_now(&caller, &id)
             .await
             .map_err(domain_error_to_status)?;
 

--- a/crates/scylla-api/src/startup.rs
+++ b/crates/scylla-api/src/startup.rs
@@ -419,6 +419,7 @@ pub async fn init_services(config: &CoreConfig) -> Result<Services, StartupError
         app_repo.clone(),
         pipeline_uc.clone(),
         dispatch_uc.clone(),
+        permission_checker.clone(),
     ));
     // Webhook ingress: shares the trigger-runner fire path; firing is the
     // TriggerFiring trait object the cron scheduler also uses.

--- a/crates/scylla-core/src/application/trigger/fire.rs
+++ b/crates/scylla-core/src/application/trigger/fire.rs
@@ -9,6 +9,7 @@ use crate::domain::clock;
 use crate::domain::entities::{AppId, Job, OrganizationId, Trigger, TriggerId};
 use crate::domain::errors::{DomainError, DomainResult};
 use crate::domain::value_objects::job::JobOrigin;
+use crate::domain::value_objects::permission::Permission;
 use crate::domain::value_objects::trigger::{TriggerInputSource, TriggerSource};
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -52,6 +53,10 @@ where
     app_repo: Arc<A>,
     pipeline_uc: Arc<PipelineUseCases<P, PR, J, PS>>,
     dispatch_uc: Arc<DispatchUseCases<W, PS>>,
+    /// Authorizes the caller on the manual `fire_now` path (`RunPipeline` on the
+    /// trigger's pipeline). The background `fire` (cron / webhook) has no caller
+    /// and does not use it.
+    permission_service: Arc<PS>,
 }
 
 impl<T, P, PR, A, J, PS, W> TriggerFireUseCases<T, P, PR, A, J, PS, W>
@@ -72,6 +77,7 @@ where
         app_repo: Arc<A>,
         pipeline_uc: Arc<PipelineUseCases<P, PR, J, PS>>,
         dispatch_uc: Arc<DispatchUseCases<W, PS>>,
+        permission_service: Arc<PS>,
     ) -> Self {
         Self {
             trigger_repo,
@@ -80,7 +86,28 @@ where
             app_repo,
             pipeline_uc,
             dispatch_uc,
+            permission_service,
         }
+    }
+
+    /// Fire the trigger `trigger_id` now on behalf of `caller` (the manual "run
+    /// now" path). Unlike the background [`fire`](Self::fire) — driven by the cron
+    /// scheduler / webhook ingress with no human principal — this authorizes the
+    /// caller first: a manual fire runs the pipeline, so it is gated by
+    /// `RunPipeline` on the trigger's pipeline (the run itself still executes as
+    /// the org's trigger-runner App). No webhook payload, so only literal inputs
+    /// apply.
+    #[instrument(skip(self, caller), fields(trigger_id = %trigger_id))]
+    pub async fn fire_now(
+        &self,
+        caller: &CallerContext,
+        trigger_id: &TriggerId,
+    ) -> DomainResult<Job> {
+        let trigger = self.trigger_repo.find_by_id(trigger_id).await?;
+        self.permission_service
+            .check(caller, Permission::RunPipeline(trigger.pipeline_id().clone()))
+            .await?;
+        self.fire(trigger_id, None, None).await
     }
 
     /// Fire the trigger `trigger_id` now. `payload` is the webhook body when the


### PR DESCRIPTION
## Summary

A PoC showed that `TriggerService.FireTriggerNow` enforced **no caller permission**: the handler ignored the authenticated principal (`let _caller`) and delegated straight to the firing engine, which authorizes the run as the org's trigger-runner App. Any authenticated principal could therefore fire any organization's trigger just by knowing its id (IDOR / missing authorization).

## Fix

The caller authorization now lives in the use case, like every other call:

- `TriggerFireUseCases::fire_now(&caller, id)` verifies `RunPipeline` on the trigger's pipeline before firing (the run itself still executes as the org's trigger-runner App).
- The handler makes a single use-case call, mirroring `create` / `set_enabled`.
- The background paths (cron scheduler, webhook ingress) still go through `fire()` with no caller, unchanged.

## Authorization audit (whole gRPC + REST surface)

Off the back of this finding, every endpoint was audited method by method (handler to use case to repository). **No other gap was found.** Every authenticated endpoint enforces the correct `Permission` at the correct scope; the rest are public-by-design and were verified.

| Handler | Methods | Status |
|---|---|---|
| agent_admin | 5 | enforced |
| agent (stream) | 4 | 3 enforced (executeJob / writeJobStatus / appendJobLog) + connect gated by app token |
| app | 9 | enforced |
| auth | 3 | public (Login pre-auth; Validate/Revoke act on own session) |
| app_auth | 1 | public (IssueToken: credential exchange) |
| grant | 4 | 3 enforced + ListGrantableRoles (static catalog, authenticated-only) |
| invitation | 4 | 3 enforced + AcceptInvite public (token is the credential) |
| job | 8 | enforced (incl. TailJobLogs -> readJobLogs) |
| oauth | 2 | public (OAuth flow) |
| organization | 10 | enforced |
| pipeline | 8 | enforced |
| policy | 7 | enforced (managePolicies) |
| project | 11 | enforced |
| registration | 1 | public (Signup) |
| role | 6 | enforced |
| secret | 3 | enforced |
| trigger | 7 | enforced (**FireTriggerNow fixed here**) |
| user | 6 | enforced |
| webhook (REST) | 1 | public at edge, per-trigger HMAC inside the handler |

Notes (not issues):

- `GrantService.ListGrantableRoles` returns a static, non-sensitive role catalog; authenticated-only by design (`_caller` intentionally unused, documented).
- `AppService` SetAppActive / CreateAppSecret / RevokeAppSecret / SetAppSecretEnabled reuse the `DeleteApp` (manage-level) permission, scoped to the app.
- Streaming RPCs `AgentService.Open` and `JobService.TailJobLogs` were confirmed correctly authorized.

Scope: this audit verifies that each endpoint enforces the correct permission at the correct scope. The correctness of the Cedar policies/roles themselves is a separate layer.

## Verification

- `cargo check` + `cargo clippy` clean.
- Trigger module unit tests pass.
