### PR TITLE
feat(api): gate public signup behind `register` cargo feature

### DIFF
--- a/crates/scylla-api/Cargo.toml
+++ b/crates/scylla-api/Cargo.toml
@@ -13,6 +13,11 @@ grpc = [
     "dep:scylla-protocol",
 ]
 
+# Public self-service signup (the gRPC RegistrationService). Off by default so a
+# deployment stays invite-only / OAuth-only unless it opts in. gRPC-only, so it
+# pulls in `grpc` (and its tonic / scylla-protocol deps).
+register = ["grpc"]
+
 [dependencies]
 # shared
 scylla-core = { workspace = true, features = ["postgres", "hash", "permission"] }

--- a/crates/scylla-api/src/grpc/handlers/mod.rs
+++ b/crates/scylla-api/src/grpc/handlers/mod.rs
@@ -14,6 +14,7 @@ pub mod organization_handler;
 pub mod pipeline_handler;
 pub mod policy_handler;
 pub mod project_handler;
+#[cfg(feature = "register")]
 pub mod registration_handler;
 pub mod role_handler;
 pub mod secret_handler;
@@ -33,6 +34,7 @@ pub use organization_handler::OrganizationHandler;
 pub use pipeline_handler::PipelineHandler;
 pub use policy_handler::PolicyHandler;
 pub use project_handler::ProjectHandler;
+#[cfg(feature = "register")]
 pub use registration_handler::RegistrationHandler;
 pub use role_handler::RoleHandler;
 pub use secret_handler::SecretHandler;

--- a/crates/scylla-api/src/grpc/mod.rs
+++ b/crates/scylla-api/src/grpc/mod.rs
@@ -7,9 +7,11 @@ pub mod streaming;
 pub use handlers::{
     AgentAdminHandler, AgentHandler, AppAuthHandler, AppHandler, AuthHandler, GrantHandler,
     InvitationHandler, JobHandler, OAuthHandler, OrganizationHandler, PipelineHandler,
-    PolicyHandler, ProjectHandler, RegistrationHandler, RoleHandler, SecretHandler, TriggerHandler,
+    PolicyHandler, ProjectHandler, RoleHandler, SecretHandler, TriggerHandler,
     UserHandler,
 };
+#[cfg(feature = "register")]
+pub use handlers::RegistrationHandler;
 pub use mappers::{
     domain_error_to_status, domain_to_proto_metadata, job_to_proto, organization_to_proto,
     pipeline_to_proto, project_to_proto, proto_to_domain_pagination, user_to_proto,

--- a/crates/scylla-api/src/startup.rs
+++ b/crates/scylla-api/src/startup.rs
@@ -7,10 +7,12 @@ use scylla_core::application::{
     CronSchedule, DispatchSecretResolver, DispatchUseCases, GrantUseCases, InvitationUseCases,
     JobLogStreamUseCase, JobLogUseCases, JobUseCases, Mailer, NoopMailer, OAuthUseCases,
     OrganizationUseCases, PendingJobScheduler, PipelineUseCases, PolicyUseCases, ProjectUseCases,
-    RoleUseCases, SecretCipher, SecretResolver, SecretUseCases, SignupUseCases,
+    RoleUseCases, SecretCipher, SecretResolver, SecretUseCases,
     TriggerCronScheduler, TriggerFireUseCases, TriggerFiring, TriggerUseCases,
     WebhookIngressUseCases, UserUseCases,
 };
+#[cfg(feature = "register")]
+use scylla_core::application::SignupUseCases;
 use scylla_core::infrastructure::LettreMailer;
 use scylla_core::infrastructure::{
     Argon2HashService, CedarPermissionService, ChaChaSecretCipher, CronScheduleService,
@@ -41,6 +43,7 @@ pub type SharedPolicyUc =
     Arc<PolicyUseCases<PgPolicyRepository, PermissionChecker, PermissionChecker>>;
 
 pub type SharedAuthUc = Arc<AuthUseCases<PgUserRepository, PgSessionRepository, Argon2HashService>>;
+#[cfg(feature = "register")]
 pub type SharedSignupUc = Arc<
     SignupUseCases<PgSignupRepository, PgSessionRepository, Argon2HashService, PermissionChecker>,
 >;
@@ -144,6 +147,7 @@ pub type SharedWebhookIngressUc =
 pub struct Services {
     pub db: PgPool,
     pub auth_uc: SharedAuthUc,
+    #[cfg(feature = "register")]
     pub signup_uc: SharedSignupUc,
     pub invitation_uc: SharedInvitationUc,
     pub oauth_uc: Option<SharedOAuthUc>,
@@ -232,6 +236,7 @@ pub async fn init_services(config: &CoreConfig) -> Result<Services, StartupError
         session_repo.clone(),
         hash_service.clone(),
     ));
+    #[cfg(feature = "register")]
     let signup_uc = Arc::new(SignupUseCases::new(
         signup_repo.clone(),
         session_repo.clone(),
@@ -479,6 +484,7 @@ pub async fn init_services(config: &CoreConfig) -> Result<Services, StartupError
     Ok(Services {
         db,
         auth_uc,
+        #[cfg(feature = "register")]
         signup_uc,
         invitation_uc,
         oauth_uc,
@@ -599,14 +605,17 @@ where
     use crate::grpc::{
         AgentAdminHandler, AgentHandler, AppAuthHandler, AppHandler, AuthHandler, GrantHandler,
         InvitationHandler, JobHandler, OAuthHandler, OrganizationHandler, PipelineHandler,
-        PolicyHandler, ProjectHandler, RegistrationHandler, RoleHandler, SecretHandler,
+        PolicyHandler, ProjectHandler, RoleHandler, SecretHandler,
         TriggerHandler, UserHandler, auth_interceptor::AuthInterceptor,
     };
+    #[cfg(feature = "register")]
+    use crate::grpc::RegistrationHandler;
     use scylla_protocol::services::invitation::{
         invitation_accept_service_server::InvitationAcceptServiceServer,
         invitation_service_server::InvitationServiceServer,
     };
     use scylla_protocol::services::oauth::oauth_service_server::OauthServiceServer;
+    #[cfg(feature = "register")]
     use scylla_protocol::services::registration::registration_service_server::RegistrationServiceServer;
     use scylla_protocol::services::{
         agent::agent_service_server::AgentServiceServer,
@@ -693,7 +702,8 @@ where
     // interceptor; it mints the bearer token apps use on every other call.
     let app_auth_service = AppAuthServiceServer::new(app_auth_handler);
 
-    // Public self-service signup.
+    // Public self-service signup — compiled in only with the `register` feature.
+    #[cfg(feature = "register")]
     let registration_service =
         RegistrationServiceServer::new(RegistrationHandler::new(services.signup_uc.clone()));
 
@@ -787,9 +797,12 @@ where
         .add_service(policy_service)
         .add_service(grant_service)
         .add_service(role_service)
-        .add_service(registration_service)
         .add_service(invitation_service)
         .add_service(invitation_accept_service);
+
+    // Public self-service signup — only registered when built with `register`.
+    #[cfg(feature = "register")]
+    let router = router.add_service(registration_service);
 
     // GitHub OAuth is only registered when configured with credentials.
     let router = match oauth_service {

--- a/crates/scylla-control-plane/Cargo.toml
+++ b/crates/scylla-control-plane/Cargo.toml
@@ -7,6 +7,11 @@ edition = "2024"
 name = "scylla-control-plane"
 path = "src/main.rs"
 
+[features]
+# Forward the public self-service signup gate to scylla-api. Off by default: the
+# shipped binary is invite-only / OAuth-only unless built with `--features register`.
+register = ["scylla-api/register"]
+
 [dependencies]
 # workspace subsystems composed in-process
 scylla-core = { workspace = true, features = ["postgres", "hash", "permission"] }


### PR DESCRIPTION
The `RegistrationService` gRPC (self-service username/password signup) is only compiled with the `register` cargo feature, which is OFF by default. The `scylla-control-plane` binary forwards the flag (`register = ["scylla-api/register"]`), so the build shipped by default is invite-only / OAuth-only unless explicitly built with `--features register`.

`register` implies `grpc` (the handler depends on tonic + scylla-protocol). `PgSignupRepository` remains ungated since it is shared with the OAuth flow.

Verify: `cargo check` + clippy green in both configurations (OFF by default and `--features register`), zero warnings.

Ops notes (no build impact):
- Default build: `RegistrationService/Signup` returns `Unimplemented`; onboarding goes through OAuth and invitations.
- gRPC reflection still advertises `RegistrationService` (combined descriptor set is ungated); a call still returns `Unimplemented`.