### PR TITLE
fix(jobs): reap running jobs whose agent is no longer connected

### DIFF
--- a/.sqlx/query-1b4ee66ce072c9270276a204030abf2fd4615a499055c541641e5e87174b7bcc.json
+++ b/.sqlx/query-1b4ee66ce072c9270276a204030abf2fd4615a499055c541641e5e87174b7bcc.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE jobs SET status = 'orphaned', finished_at = now(), updated_at = now() WHERE status = 'running' AND (agent_app_id IS NULL OR NOT (agent_app_id = ANY($1)))",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1b4ee66ce072c9270276a204030abf2fd4615a499055c541641e5e87174b7bcc"
+}

--- a/crates/scylla-agent/src/reporter.rs
+++ b/crates/scylla-agent/src/reporter.rs
@@ -93,11 +93,6 @@ impl JobReporter {
         self.outcome = JobOutcome::Failure(error);
     }
 
-    #[must_use]
-    pub fn publisher(&self) -> StatusPublisher {
-        self.publisher.clone()
-    }
-
     /// Emit the terminal event (`JobCompleted` / `JobFailed`) and consume the guard.
     pub async fn finalize(self) -> Result<(), ExecutionError> {
         let event = match self.outcome {

--- a/crates/scylla-api/src/startup.rs
+++ b/crates/scylla-api/src/startup.rs
@@ -3,13 +3,13 @@ use crate::error::StartupError;
 use http::{HeaderName, HeaderValue, Method};
 use tokio::sync::Notify;
 use scylla_core::application::{
-    AgentUseCases, AppTokenUseCases, AppUseCases, AuditLog, AuthUseCases, BootstrapUseCases,
-    CronSchedule, DispatchSecretResolver, DispatchUseCases, GrantUseCases, InvitationUseCases,
-    JobLogStreamUseCase, JobLogUseCases, JobUseCases, Mailer, NoopMailer, OAuthUseCases,
-    OrganizationUseCases, PendingJobScheduler, PipelineUseCases, PolicyUseCases, ProjectUseCases,
-    RoleUseCases, SecretCipher, SecretResolver, SecretUseCases, SignupUseCases,
-    TriggerCronScheduler, TriggerFireUseCases, TriggerFiring, TriggerUseCases,
-    WebhookIngressUseCases, UserUseCases,
+    AgentDispatch, AgentUseCases, AppTokenUseCases, AppUseCases, AuditLog, AuthUseCases,
+    BootstrapUseCases, CronSchedule, DispatchSecretResolver, DispatchUseCases, GrantUseCases,
+    InvitationUseCases, JobLogStreamUseCase, JobLogUseCases, JobReaper, JobUseCases, Mailer,
+    NoopMailer, OAuthUseCases, OrganizationUseCases, PendingJobScheduler, PipelineUseCases,
+    PolicyUseCases, ProjectUseCases, RoleUseCases, SecretCipher, SecretResolver, SecretUseCases,
+    SignupUseCases, TriggerCronScheduler, TriggerFireUseCases, TriggerFiring, TriggerUseCases,
+    UserUseCases, WebhookIngressUseCases,
 };
 use scylla_core::infrastructure::LettreMailer;
 use scylla_core::infrastructure::{
@@ -472,6 +472,27 @@ pub async fn init_services(config: &CoreConfig) -> Result<Services, StartupError
                     _ = tick.tick() => {}
                 }
                 scheduler.drain().await;
+            }
+        });
+    }
+
+    // Orphaned-job reaper: a job is `running` only while its agent owns it. If
+    // that agent's stream drops without a terminal report (crash, network, or a
+    // control plane restart that forgets every live stream), the job would sit
+    // `running` forever. Level-triggered reconciliation orphans every running
+    // job whose agent is not currently connected: once at boot (nothing is
+    // connected yet, so every pre-restart running job is cleared) and on a
+    // periodic tick.
+    {
+        let reaper = JobReaper::new(job_repo.clone());
+        let registry = agent_registry.clone();
+        tokio::spawn(async move {
+            reaper.reap(&[]).await;
+            let mut tick = tokio::time::interval(std::time::Duration::from_secs(30));
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                tick.tick().await;
+                reaper.reap(&registry.connected()).await;
             }
         });
     }

--- a/crates/scylla-core/src/application/agent/scheduler.rs
+++ b/crates/scylla-core/src/application/agent/scheduler.rs
@@ -138,6 +138,9 @@ mod tests {
                 .push((job_id.to_string(), app_id.as_str().to_string()));
             Ok(())
         }
+        async fn orphan_running_without_agents(&self, _: &[AppId]) -> DomainResult<u64> {
+            unimplemented!()
+        }
         async fn create(&self, _: &Job) -> DomainResult<Job> {
             unimplemented!()
         }

--- a/crates/scylla-core/src/application/job/mod.rs
+++ b/crates/scylla-core/src/application/job/mod.rs
@@ -3,6 +3,7 @@ pub mod log_repository;
 pub mod log_stream_port;
 pub mod log_stream_use_case;
 pub mod log_use_case;
+pub mod reaper;
 pub mod repository;
 pub mod use_case;
 
@@ -11,5 +12,6 @@ pub use log_repository::JobLogRepository;
 pub use log_stream_port::{JobLogLiveStream, JobLogStreamPort};
 pub use log_stream_use_case::JobLogStreamUseCase;
 pub use log_use_case::JobLogUseCases;
+pub use reaper::JobReaper;
 pub use repository::JobRepository;
 pub use use_case::JobUseCases;

--- a/crates/scylla-core/src/application/job/reaper.rs
+++ b/crates/scylla-core/src/application/job/reaper.rs
@@ -1,0 +1,152 @@
+use crate::application::job::repository::JobRepository;
+use crate::domain::entities::AppId;
+use std::sync::Arc;
+use tracing::{instrument, warn};
+
+/// Reaps stranded runs. A job is `running` only while its owning agent holds it,
+/// so a running job whose agent is not currently connected will never reach a
+/// terminal report on its own (the agent crashed, the stream dropped, or the
+/// control plane restarted and forgot every live stream). Level-triggered
+/// reconciliation — desired state ("running ⇒ a connected agent owns it") vs
+/// actual — rather than reacting to disconnect edges, so it is immune to
+/// reconnect races and covers a control-plane restart in the same code path.
+///
+/// Runs once at boot (nothing is connected yet, so every leftover running job
+/// from a previous process is orphaned) and on a periodic tick with the live
+/// connection set.
+pub struct JobReaper<J: JobRepository> {
+    job_repo: Arc<J>,
+}
+
+impl<J: JobRepository> JobReaper<J> {
+    #[must_use]
+    pub fn new(job_repo: Arc<J>) -> Self {
+        Self { job_repo }
+    }
+
+    /// Orphan every `running` job whose agent is not in `connected`. Best-effort:
+    /// a failed reconciliation is logged and retried on the next tick, never
+    /// propagated. Returns how many jobs were orphaned this pass.
+    #[instrument(skip(self, connected), fields(connected = connected.len()))]
+    pub async fn reap(&self, connected: &[AppId]) -> u64 {
+        match self.job_repo.orphan_running_without_agents(connected).await {
+            Ok(0) => 0,
+            Ok(n) => {
+                warn!(
+                    orphaned = n,
+                    "reaped running jobs whose agent is no longer connected"
+                );
+                n
+            }
+            Err(e) => {
+                warn!(error = %e, "job reaper: reconciliation pass failed");
+                0
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::entities::{Job, JobId, OrganizationId, PipelineId, ProjectId};
+    use crate::domain::errors::DomainResult;
+    use crate::domain::value_objects::{PaginatedResult, PaginationParams};
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+
+    /// Records the `connected` set each `reap` passed to the repo and returns a
+    /// fixed orphan count. Every other method is unused here.
+    struct RecordingJobs {
+        orphaned: u64,
+        seen_connected: Mutex<Vec<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl JobRepository for RecordingJobs {
+        async fn orphan_running_without_agents(&self, connected: &[AppId]) -> DomainResult<u64> {
+            self.seen_connected
+                .lock()
+                .unwrap()
+                .push(connected.iter().map(|a| a.as_str().to_string()).collect());
+            Ok(self.orphaned)
+        }
+        async fn create(&self, _: &Job) -> DomainResult<Job> {
+            unimplemented!()
+        }
+        async fn find_by_id(&self, _: &JobId) -> DomainResult<Job> {
+            unimplemented!()
+        }
+        async fn update(&self, _: &Job) -> DomainResult<Job> {
+            unimplemented!()
+        }
+        async fn set_agent(&self, _: &JobId, _: &AppId) -> DomainResult<()> {
+            unimplemented!()
+        }
+        async fn list_pending_unassigned(&self) -> DomainResult<Vec<Job>> {
+            unimplemented!()
+        }
+        async fn delete(&self, _: &JobId) -> DomainResult<()> {
+            unimplemented!()
+        }
+        async fn list_all(
+            &self,
+            _: Option<&PaginationParams>,
+        ) -> DomainResult<PaginatedResult<Job>> {
+            unimplemented!()
+        }
+        async fn list_by_pipeline(
+            &self,
+            _: &PipelineId,
+            _: Option<&PaginationParams>,
+        ) -> DomainResult<PaginatedResult<Job>> {
+            unimplemented!()
+        }
+        async fn list_by_project(
+            &self,
+            _: &ProjectId,
+            _: Option<&PaginationParams>,
+        ) -> DomainResult<PaginatedResult<Job>> {
+            unimplemented!()
+        }
+        async fn list_by_organization(
+            &self,
+            _: &OrganizationId,
+            _: Option<&PaginationParams>,
+        ) -> DomainResult<PaginatedResult<Job>> {
+            unimplemented!()
+        }
+    }
+
+    #[tokio::test]
+    async fn reap_forwards_the_connected_set_and_returns_the_count() {
+        let jobs = Arc::new(RecordingJobs {
+            orphaned: 3,
+            seen_connected: Mutex::new(vec![]),
+        });
+        let reaper = JobReaper::new(jobs.clone());
+
+        // Boot pass: nothing connected — the repo is asked to reap unconditionally.
+        assert_eq!(reaper.reap(&[]).await, 3);
+        // Periodic pass: one live agent is excluded from reaping.
+        assert_eq!(reaper.reap(&[AppId::new("agent-1")]).await, 3);
+
+        let seen = jobs.seen_connected.lock().unwrap();
+        assert_eq!(seen.len(), 2);
+        assert!(
+            seen[0].is_empty(),
+            "boot pass reaps with an empty connected set"
+        );
+        assert_eq!(seen[1], vec!["agent-1".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn reap_reports_zero_when_nothing_is_stranded() {
+        let jobs = Arc::new(RecordingJobs {
+            orphaned: 0,
+            seen_connected: Mutex::new(vec![]),
+        });
+        let reaper = JobReaper::new(jobs);
+        assert_eq!(reaper.reap(&[]).await, 0);
+    }
+}

--- a/crates/scylla-core/src/application/job/repository.rs
+++ b/crates/scylla-core/src/application/job/repository.rs
@@ -20,6 +20,15 @@ pub trait JobRepository {
     /// Oldest first (FIFO); not paginated — the scheduler drains the whole set.
     async fn list_pending_unassigned(&self) -> DomainResult<Vec<Job>>;
 
+    /// Reconcile stranded runs: mark every `running` job whose `agent_app_id` is
+    /// not in `connected` as `Orphaned` (finished now). A job is `running` only
+    /// while its owning agent holds it, so a running job with no connected agent
+    /// is stranded (the agent crashed, the stream dropped without a terminal
+    /// report, or the control plane restarted and forgot every live stream).
+    /// Called at boot (`connected` empty ⇒ every pre-restart running job is
+    /// reaped) and periodically. Returns how many jobs were orphaned.
+    async fn orphan_running_without_agents(&self, connected: &[AppId]) -> DomainResult<u64>;
+
     async fn delete(&self, id: &JobId) -> DomainResult<()>;
 
     async fn list_all(

--- a/crates/scylla-core/src/application/mod.rs
+++ b/crates/scylla-core/src/application/mod.rs
@@ -44,7 +44,7 @@ pub use caller::{CallerContext, ServiceIdentity};
 pub use invitation::{AcceptOutcome, InvitationRepository, InvitationUseCases};
 pub use job::{
     JobEvent, JobLogLiveStream, JobLogRepository, JobLogStreamPort, JobLogStreamUseCase,
-    JobLogUseCases, JobRepository, JobUseCases,
+    JobLogUseCases, JobReaper, JobRepository, JobUseCases,
 };
 pub use mail::{Mailer, NoopMailer};
 pub use oauth::{

--- a/crates/scylla-core/src/infrastructure/persistence/postgres/jobs/repository.rs
+++ b/crates/scylla-core/src/infrastructure/persistence/postgres/jobs/repository.rs
@@ -49,6 +49,11 @@ impl JobRepository for PgJobRepository {
         queries::list_pending_unassigned(&self.pool).await
     }
 
+    #[instrument(skip(self, connected), fields(connected = connected.len()))]
+    async fn orphan_running_without_agents(&self, connected: &[AppId]) -> DomainResult<u64> {
+        queries::orphan_running_without_agents(&self.pool, connected).await
+    }
+
     #[instrument(skip(self), fields(job_id = %id))]
     async fn delete(&self, id: &JobId) -> DomainResult<()> {
         queries::delete(&self.pool, id).await
@@ -197,6 +202,32 @@ pub mod queries {
         .await
         .to_domain()?;
         Ok(())
+    }
+
+    /// Orphan every `running` job whose `agent_app_id` is not among `connected`
+    /// (or is NULL), stamping `finished_at`/`updated_at`. `WHERE status =
+    /// 'running'` keeps this to the one valid `Running → Orphaned` transition; an
+    /// empty `connected` reaps every running job (boot reconciliation). Returns
+    /// the number reaped.
+    pub async fn orphan_running_without_agents<'e, E>(
+        executor: E,
+        connected: &[AppId],
+    ) -> DomainResult<u64>
+    where
+        E: PgExecutor<'e>,
+    {
+        let connected_ids: Vec<String> = connected.iter().map(|a| a.as_str().to_owned()).collect();
+        let result = sqlx::query!(
+            "UPDATE jobs \
+             SET status = 'orphaned', finished_at = now(), updated_at = now() \
+             WHERE status = 'running' \
+               AND (agent_app_id IS NULL OR NOT (agent_app_id = ANY($1)))",
+            &connected_ids,
+        )
+        .execute(executor)
+        .await
+        .to_domain()?;
+        Ok(result.rows_affected())
     }
 
     /// Pending jobs with no agent yet — the backlog to (re)dispatch when a

--- a/crates/scylla-core/src/infrastructure/persistence/postgres/jobs/tests.rs
+++ b/crates/scylla-core/src/infrastructure/persistence/postgres/jobs/tests.rs
@@ -57,6 +57,86 @@ async fn update_persists_started_finished_timestamps(pool: PgPool) {
     assert!(found.updated_at() <= Utc::now());
 }
 
+/// The reaper orphans running jobs whose agent is no longer connected, and only
+/// those: a running job owned by a connected agent, a pending job, and a
+/// terminal job are all left untouched. An empty connected set (boot
+/// reconciliation) then orphans every remaining running job.
+#[sqlx::test(migrations = "../../migrations")]
+async fn orphan_running_without_agents_reaps_only_stranded_running_jobs(pool: PgPool) {
+    use crate::application::AppRepository;
+    use crate::application::authz::grant::{Grant, ORGANIZATION_AGENT_ROLE, Principal, Scope};
+    use crate::domain::entities::{Agent, App, AppCredential};
+    use crate::domain::value_objects::app::{AppName, AppSecretHash, AppSecretLabel};
+    use crate::domain::value_objects::role::name::RoleName;
+    use crate::infrastructure::persistence::postgres::PgAppRepository;
+
+    let (org, _project, pipeline) = seed_org_project_pipeline(&pool, "reap").await;
+    let repo = PgJobRepository::new(pool.clone());
+
+    // A live agent to own one of the running jobs.
+    let app = App::create(org.id().clone(), AppName::new("live-runner").unwrap());
+    let credential = AppCredential::create(
+        app.id().clone(),
+        AppSecretLabel::new("default").unwrap(),
+        AppSecretHash::new("$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$aGFzaGhhc2g").unwrap(),
+    );
+    let agent = Agent::create(app.id().clone());
+    let grant = Grant::new(
+        Principal::App(app.id().clone()),
+        RoleName::new(ORGANIZATION_AGENT_ROLE).unwrap(),
+        Scope::Organization(org.id().clone()),
+    );
+    PgAppRepository::new(pool.clone())
+        .provision_agent(&app, &credential, &agent, &grant)
+        .await
+        .expect("provision agent");
+
+    // owned: running, assigned to the live (connected) agent.
+    let mut owned = job(&pipeline);
+    owned.start().unwrap();
+    repo.create(&owned).await.unwrap();
+    repo.set_agent(owned.id(), app.id()).await.unwrap();
+    // stranded: running, no agent.
+    let mut stranded = job(&pipeline);
+    stranded.start().unwrap();
+    repo.create(&stranded).await.unwrap();
+    // pending + terminal: never reaped.
+    let pending = job(&pipeline);
+    repo.create(&pending).await.unwrap();
+    let done = JobBuilder::new(&pipeline)
+        .terminated(JobStatus::Completed)
+        .build();
+    repo.create(&done).await.unwrap();
+
+    // With the live agent connected, only the stranded running job is reaped.
+    let reaped = repo
+        .orphan_running_without_agents(std::slice::from_ref(app.id()))
+        .await
+        .unwrap();
+    assert_eq!(reaped, 1, "only the agent-less running job is orphaned");
+    assert_eq!(status(&repo, owned.id()).await, JobStatus::Running);
+    assert_eq!(status(&repo, stranded.id()).await, JobStatus::Orphaned);
+    assert_eq!(status(&repo, pending.id()).await, JobStatus::Pending);
+    assert_eq!(status(&repo, done.id()).await, JobStatus::Completed);
+    assert!(
+        repo.find_by_id(stranded.id())
+            .await
+            .unwrap()
+            .finished_at()
+            .is_some(),
+        "an orphaned job is stamped finished",
+    );
+
+    // Boot reconciliation: an empty connected set reaps the still-running owned job.
+    let reaped_at_boot = repo.orphan_running_without_agents(&[]).await.unwrap();
+    assert_eq!(reaped_at_boot, 1, "the last running job is reaped at boot");
+    assert_eq!(status(&repo, owned.id()).await, JobStatus::Orphaned);
+}
+
+async fn status(repo: &PgJobRepository, id: &crate::domain::entities::JobId) -> JobStatus {
+    repo.find_by_id(id).await.unwrap().status()
+}
+
 #[sqlx::test(migrations = "../../migrations")]
 async fn list_by_pipeline_filters(pool: PgPool) {
     let org = seed_org(&pool, "acme").await;


### PR DESCRIPTION
## What

A control-plane-side reaper marks `running` jobs whose agent is no longer connected as `Orphaned`, so a job can never be stranded in `running` forever.

## Why

A job is `running` only while its owning agent holds it. If that agent's stream drops without a terminal report (agent crash, network cut, or a control plane restart that forgets every live stream), the job stays `running` indefinitely: the agent abandons it on the publish failure and nothing server-side reconciles it. `JobStatus::Orphaned` already existed but no code ever set it, and the pending-job scheduler only drains `pending` jobs.

Found during the multi-agent review (high severity) and confirmed by the completeness critic (no startup reconciliation of `running` jobs either).

## How

A **level-triggered** reaper, not an edge-triggered disconnect hook: it reconciles desired state ("a running job is owned by a connected agent") against actual, which is immune to reconnect races and covers a control-plane restart in the same code path.

- `JobRepository::orphan_running_without_agents(connected)`: `UPDATE jobs SET status='orphaned', finished_at=now(), updated_at=now() WHERE status='running' AND (agent_app_id IS NULL OR NOT (agent_app_id = ANY($1)))`. `WHERE status='running'` keeps it to the one valid `Running → Orphaned` transition.
- `JobReaper` application service (mirrors `PendingJobScheduler`: a system component, no Cedar caller).
- Spawned in `startup`: one boot pass (empty connected set ⇒ every pre-restart running job is cleared) plus a 30s periodic tick with the live connection set.
- Removed the now-unused `JobReporter::publisher()` accessor (dead code flagged in the review).

## Tests

- 2 unit tests for `JobReaper` (boot pass forwards an empty set; the live agent is excluded).
- 1 `#[sqlx::test]`: a connected agent's running job is kept, a stranded running job is orphaned (and stamped finished), pending/terminal jobs are untouched, and a boot pass then reaps the rest.
- Full workspace suite green (300 tests), `clippy --all-features` clean, `.sqlx` regenerated (one new entry).

## Scope / follow-up

This is the authoritative server-side guarantee that no job stays `running` forever. Agent-side re-emission of a terminal event after reconnect (so a job that actually finished during a blip reports its true outcome instead of being orphaned) is a separate enhancement: it only matters if the executor is first made resilient to transient publish failures (buffer + retry), since today it abandons the job on a publish error. Tracked for later.
