### PR TITLE
fix(config): inject the secret master key via env, warn on the dev key

### DIFF
--- a/crates/scylla-api/src/config.rs
+++ b/crates/scylla-api/src/config.rs
@@ -56,9 +56,22 @@ pub struct WebhookConfig {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SecretsConfig {
     /// Master key for project-secret AEAD encryption, as 64 hex chars (32 bytes).
-    /// Keep it out of source control in real deployments (inject at deploy time).
+    /// Keep it out of source control in real deployments (inject at deploy time
+    /// via [`MASTER_KEY_ENV`]).
     pub master_key: String,
 }
+
+/// Environment variable that overrides the project-secret master key, so real
+/// deployments inject it at deploy time instead of committing it to a config
+/// file. Set, it takes precedence over `[secrets].master_key` and enables the
+/// secret store even when the file omits `[secrets]`.
+pub const MASTER_KEY_ENV: &str = "SCYLLA_MASTER_KEY";
+
+/// The master key committed in the shipped dev/demo config (`config/docker.toml`).
+/// It is public, so using it in a real deployment makes every project secret and
+/// webhook HMAC secret trivially decryptable by anyone with the repo. Detected at
+/// startup to warn loudly.
+pub const DEV_MASTER_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct OauthConfig {
@@ -220,11 +233,99 @@ impl CoreConfig {
         Ok(toml::from_str(&content)?)
     }
 
+    /// Overlay environment overrides on top of the file config. Currently only
+    /// [`MASTER_KEY_ENV`], so a deployment can inject the master key at deploy
+    /// time rather than committing it. Call once, right after loading the file.
+    pub fn apply_env_overrides(&mut self) {
+        if let Ok(key) = std::env::var(MASTER_KEY_ENV) {
+            self.override_master_key(&key);
+        }
+    }
+
+    /// Set the project-secret master key, enabling the secret store if the file
+    /// omitted `[secrets]`. A blank value is ignored (an unset/empty env var must
+    /// not wipe a file-provided key). Separated from env reading so it is
+    /// unit-testable without touching process environment.
+    pub fn override_master_key(&mut self, key: &str) {
+        let key = key.trim();
+        if !key.is_empty() {
+            self.secrets = Some(SecretsConfig {
+                master_key: key.to_owned(),
+            });
+        }
+    }
+
+    /// Whether the effective master key is the public dev/demo one. A real
+    /// deployment using it has no secret confidentiality at all.
+    #[must_use]
+    pub fn uses_dev_master_key(&self) -> bool {
+        self.secrets
+            .as_ref()
+            .is_some_and(|s| s.master_key.trim().eq_ignore_ascii_case(DEV_MASTER_KEY))
+    }
+
     pub fn print_example() {
         let config = CoreConfig::default();
         match toml::to_string_pretty(&config) {
             Ok(s) => println!("{s}"),
             Err(e) => eprintln!("Error generating example config: {e}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn override_master_key_enables_secret_store_when_absent() {
+        let mut config = CoreConfig::default();
+        assert!(config.secrets.is_none());
+        config.override_master_key("aa11bb22");
+        assert_eq!(config.secrets.unwrap().master_key, "aa11bb22");
+    }
+
+    #[test]
+    fn override_master_key_replaces_a_file_provided_key() {
+        let mut config = CoreConfig {
+            secrets: Some(SecretsConfig {
+                master_key: DEV_MASTER_KEY.to_owned(),
+            }),
+            ..CoreConfig::default()
+        };
+        config.override_master_key("  deadbeef  ");
+        assert_eq!(
+            config.secrets.unwrap().master_key,
+            "deadbeef",
+            "trimmed + replaced"
+        );
+    }
+
+    #[test]
+    fn override_master_key_ignores_blank() {
+        // An unset/empty env var must never wipe a file-provided key.
+        let mut config = CoreConfig {
+            secrets: Some(SecretsConfig {
+                master_key: "real-key".to_owned(),
+            }),
+            ..CoreConfig::default()
+        };
+        config.override_master_key("   ");
+        assert_eq!(config.secrets.unwrap().master_key, "real-key");
+    }
+
+    #[test]
+    fn uses_dev_master_key_detects_the_public_key() {
+        let mut config = CoreConfig::default();
+        assert!(!config.uses_dev_master_key(), "no secrets configured");
+
+        config.override_master_key(DEV_MASTER_KEY);
+        assert!(config.uses_dev_master_key());
+        // Case-insensitive, whitespace-tolerant.
+        config.override_master_key(&format!("  {}  ", DEV_MASTER_KEY.to_uppercase()));
+        assert!(config.uses_dev_master_key());
+
+        config.override_master_key("a-real-unique-production-key");
+        assert!(!config.uses_dev_master_key());
     }
 }

--- a/crates/scylla-control-plane/src/config.rs
+++ b/crates/scylla-control-plane/src/config.rs
@@ -42,4 +42,16 @@ impl ControlPlaneConfig {
             Err(e) => eprintln!("Error generating example config: {e}"),
         }
     }
+
+    /// Overlay environment overrides on the loaded config (see
+    /// [`scylla_api::CoreConfig::apply_env_overrides`]).
+    pub fn apply_env_overrides(&mut self) {
+        self.api.apply_env_overrides();
+    }
+
+    /// Whether the effective project-secret master key is the public dev one.
+    #[must_use]
+    pub fn uses_dev_master_key(&self) -> bool {
+        self.api.uses_dev_master_key()
+    }
 }

--- a/crates/scylla-control-plane/src/main.rs
+++ b/crates/scylla-control-plane/src/main.rs
@@ -47,11 +47,28 @@ async fn run(args: Args) -> Result<()> {
 }
 
 fn load_config(args: &Args) -> Result<ControlPlaneConfig> {
-    if let Some(config_path) = &args.config {
+    let mut config = if let Some(config_path) = &args.config {
         ControlPlaneConfig::from_file(config_path)
-            .with_context(|| format!("Failed to load configuration from {}", config_path))
+            .with_context(|| format!("Failed to load configuration from {}", config_path))?
     } else {
         tracing::info!("No configuration file provided, using defaults");
-        Ok(ControlPlaneConfig::default())
+        ControlPlaneConfig::default()
+    };
+
+    // Let a deployment inject the project-secret master key at deploy time
+    // instead of committing it to a config file.
+    config.apply_env_overrides();
+
+    // The shipped dev/demo config carries a PUBLIC master key. Using it in a real
+    // deployment leaves every project secret and webhook secret decryptable by
+    // anyone with the repo, so refuse to stay quiet about it.
+    if config.uses_dev_master_key() {
+        tracing::error!(
+            "SECURITY: project secrets are encrypted with the PUBLIC dev master key, so they are \
+             NOT confidential. Set {} to a unique 64-hex-char key before exposing this instance.",
+            scylla_api::config::MASTER_KEY_ENV,
+        );
     }
+
+    Ok(config)
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,9 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-scylla}
       POSTGRES_DB: ${POSTGRES_DB:-scylla}
     ports:
-      - "5432:5432"
+      # Bind to loopback only: services reach Postgres over the compose network
+      # (postgres:5432); the host publish is for local tooling, not the world.
+      - "127.0.0.1:5432:5432"
     volumes:
       # PG 18+ stores data under /var/lib/postgresql/<major>/ — mounting the
       # parent dir keeps `pg_upgrade --link` viable when moving to PG 19+.
@@ -35,6 +37,10 @@ services:
       RUST_LOG: info
       # Override DatabaseConfig.url via env so secrets stay out of the image.
       DATABASE_URL: postgres://${POSTGRES_USER:-scylla}:${POSTGRES_PASSWORD:-scylla}@postgres:5432/${POSTGRES_DB:-scylla}
+      # Project-secret master key. Inject a unique 64-hex-char value here (or in a
+      # .env file) for any real deployment: left empty it falls back to the PUBLIC
+      # dev key in docker.toml, which offers NO secret confidentiality.
+      SCYLLA_MASTER_KEY: ${SCYLLA_MASTER_KEY:-}
     command: ["--config", "/app/config/docker.toml"]
     volumes:
       - ./crates/scylla-control-plane/config:/app/config:ro


### PR DESCRIPTION
## What

Adds a `SCYLLA_MASTER_KEY` environment override for the project-secret master key and makes the control plane warn loudly when it is running on the public dev key. Hardens the shipped compose stack.

## Why

`config/docker.toml` (the stack the README tells beta users to `just up`) hardcodes a **public** master key, and `SecretsConfig` only read it from the config file with no override. So every self-hosted install AEAD-encrypts its project secrets (`project_secrets.encrypted_value`) and webhook HMAC secrets (`pipeline_triggers.webhook_secret_enc`) with a key that is committed to a public repo. Combined with host-published Postgres on `0.0.0.0`, the encryption was effectively decorative.

High-severity finding from the multi-agent review.

## How

- `SCYLLA_MASTER_KEY` overrides the file key and enables the secret store even when the file omits `[secrets]`. A blank value is ignored, so an unset env var never wipes a file-provided key (`CoreConfig::apply_env_overrides` / `override_master_key`).
- Applied in the control plane's `load_config`, right after reading the file. If the effective key is the public dev key, it logs a loud `SECURITY` error at startup (`uses_dev_master_key`).
- `docker-compose.yaml`: pass `SCYLLA_MASTER_KEY` through (empty default, so the demo still boots on the dev key), and bind Postgres to `127.0.0.1:5432` so the host publish is loopback-only rather than `0.0.0.0`.

## Tests

- 4 unit tests: override sets/replaces the key, ignores a blank value, and dev-key detection is case-insensitive and whitespace-tolerant.
- `cargo clippy -p scylla-api -p scylla-control-plane --all-features` clean; control plane builds; `docker compose config` validates.

## Deliberately out of scope (kept minimal, chose to warn not refuse)

- **Warn, not refuse-to-start:** refusing would break the intentional `just up` beta demo, which ships the dev key. A loud startup error plus a working env override is the non-breaking remediation. A future `refuse-unless-explicitly-allowed` mode could layer on top.
- Two related findings are left for their own PRs: the control plane still `debug!`-logs the full config (incl. secrets), and the bootstrap admin is a fixed `admin/admin123`.
