### PR TITLE
test(agent,authz): cover the executor and add PermissionService test doubles

### DIFF
--- a/crates/scylla-agent/src/executor.rs
+++ b/crates/scylla-agent/src/executor.rs
@@ -587,7 +587,218 @@ async fn publish_log_line(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use scylla_protocol::services::agent::JobEventKind;
+    use scylla_core::domain::value_objects::pipeline::{EnvKey, EnvVar, NodeId, WorkingDir};
+    use scylla_protocol::services::agent::{JobEventKind, JobStatus as ProtoJobStatus};
+
+    /// A unique temp path per test tag, keyed on pid to avoid collisions with
+    /// parallel test binaries (matches the existing test's manual-temp style, so
+    /// no `tempfile` dependency is pulled in).
+    fn tmp_root(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("scylla-exec-{tag}-{}", std::process::id()))
+    }
+
+    /// Build a script (`sh`) node with optional deps, working dir and literal env.
+    fn script_node(
+        id: &str,
+        deps: &[&str],
+        script: &str,
+        working_dir: Option<&str>,
+        env: &[(&str, &str)],
+    ) -> PipelineNode {
+        let node_id = NodeId::new(id).unwrap();
+        let deps = deps.iter().map(|d| NodeId::new(*d).unwrap()).collect();
+        let step = Step::script(script.to_string(), Shell::Sh).unwrap();
+        let working_dir = working_dir.map(|w| WorkingDir::new(w).unwrap());
+        let env = env
+            .iter()
+            .map(|(k, v)| EnvVar::literal(EnvKey::new(*k).unwrap(), (*v).to_string()))
+            .collect();
+        PipelineNode::new(node_id, deps, step, working_dir, env)
+    }
+
+    /// Drain every emitted message into (status events, concatenated log lines).
+    /// Safe to call right after `run()` returns: the executor awaits its log
+    /// streamers before finishing, so all lines are already queued.
+    fn drain(rx: &mut mpsc::Receiver<AgentUp>) -> (Vec<ProtoJobStatus>, String) {
+        let mut statuses = Vec::new();
+        let mut logs = String::new();
+        while let Ok(msg) = rx.try_recv() {
+            match msg.payload {
+                Some(agent_up::Payload::Status(s)) => statuses.push(s),
+                Some(agent_up::Payload::Log(l)) => {
+                    logs.push_str(&l.line);
+                    logs.push('\n');
+                }
+                None => {}
+            }
+        }
+        (statuses, logs)
+    }
+
+    fn kinds(statuses: &[ProtoJobStatus]) -> Vec<i32> {
+        statuses.iter().map(|s| s.kind).collect()
+    }
+
+    #[test]
+    fn redact_masks_every_occurrence_and_ignores_empty() {
+        assert_eq!(
+            redact("token=abc123 again abc123".into(), &["abc123".into()]),
+            "token=*** again ***",
+        );
+        // An empty mask must be a no-op, not replace between every character.
+        assert_eq!(redact("plain".into(), &[String::new()]), "plain");
+        assert_eq!(
+            redact("nothing here".into(), &["secret".into()]),
+            "nothing here"
+        );
+    }
+
+    #[tokio::test]
+    async fn masked_values_are_redacted_in_job_logs() {
+        let root = tmp_root("redact");
+        let (tx, mut rx) = mpsc::channel(64);
+        let exec = Executor::new(
+            tx,
+            "job-redact".into(),
+            root.clone(),
+            false,
+            vec!["s3cr3t-value".into()],
+        );
+        // The secret arrives as a node env literal (as it would after control-plane
+        // resolution) and is echoed; the emitted log line must be scrubbed.
+        let node = script_node(
+            "n1",
+            &[],
+            "echo \"leaking $TOKEN here\"",
+            None,
+            &[("TOKEN", "s3cr3t-value")],
+        );
+        exec.run(vec![node]).await.unwrap();
+        let (_statuses, logs) = drain(&mut rx);
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert!(
+            logs.contains("***"),
+            "masked value should be redacted; logs: {logs:?}"
+        );
+        assert!(
+            !logs.contains("s3cr3t-value"),
+            "the raw secret must never reach the log stream; logs: {logs:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_environment_does_not_leak_into_jobs() {
+        // Pick a variable in the agent's own environment that the allowlist does
+        // NOT restore and the shell does not auto-set, to prove `env_clear()`
+        // drops it. In a cargo test run there is always such a var (USER,
+        // CARGO_*, ...); the reserved-context assertion below holds regardless.
+        const KEPT: [&str; 8] = [
+            "PATH", "HOME", "LANG", "LC_ALL", "TERM", "CI", "PWD", "SHLVL",
+        ];
+        let probe = std::env::vars()
+            .map(|(k, _)| k)
+            .find(|k| {
+                !KEPT.contains(&k.as_str())
+                    && !k.starts_with("SCYLLA_")
+                    && k != "_"
+                    && k != "OLDPWD"
+                    && !k.is_empty()
+                    && k.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+            })
+            .unwrap_or_else(|| "SCYLLA_NO_SUCH_VAR".to_string());
+
+        let root = tmp_root("envclear");
+        let (tx, mut rx) = mpsc::channel(64);
+        let exec = Executor::new(tx, "job-env".into(), root.clone(), false, vec![]);
+        let script = format!("echo \"LEAK=[${{{probe}}}]\"; echo \"JOB=[$SCYLLA_JOB_ID]\"");
+        exec.run(vec![script_node("n1", &[], &script, None, &[])])
+            .await
+            .unwrap();
+        let (_statuses, logs) = drain(&mut rx);
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert!(
+            logs.contains("LEAK=[]"),
+            "the agent's own env var `{probe}` must not leak into the job; logs: {logs:?}",
+        );
+        assert!(
+            logs.contains("JOB=[job-env]"),
+            "reserved SCYLLA_JOB_ID must still be injected; logs: {logs:?}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn working_directory_escaping_the_workspace_is_rejected() {
+        let root = tmp_root("escape");
+        let outside = tmp_root("escape-outside");
+        let _ = std::fs::remove_dir_all(&root);
+        let _ = std::fs::remove_dir_all(&outside);
+        std::fs::create_dir_all(&outside).unwrap();
+        let workspace = root.join("job-escape");
+        std::fs::create_dir_all(&workspace).unwrap();
+        // A symlink inside the workspace that resolves outside it.
+        std::os::unix::fs::symlink(&outside, workspace.join("out")).unwrap();
+
+        let (tx, mut rx) = mpsc::channel(64);
+        let exec = Executor::new(tx, "job-escape".into(), root.clone(), false, vec![]);
+        let node = script_node("n1", &[], "echo hi", Some("out"), &[]);
+        let result = exec.run(vec![node]).await;
+        let (statuses, _logs) = drain(&mut rx);
+        let _ = std::fs::remove_dir_all(&root);
+        let _ = std::fs::remove_dir_all(&outside);
+
+        assert!(
+            result.is_err(),
+            "a working dir escaping the workspace must fail the job"
+        );
+        assert!(
+            kinds(&statuses).contains(&(JobEventKind::JobFailed as i32)),
+            "the job must still report a terminal JobFailed",
+        );
+    }
+
+    #[tokio::test]
+    async fn a_nonzero_exit_code_maps_to_node_failed() {
+        let root = tmp_root("exit");
+        let (tx, mut rx) = mpsc::channel(64);
+        let exec = Executor::new(tx, "job-exit".into(), root.clone(), false, vec![]);
+        let err = exec
+            .run(vec![script_node("n1", &[], "exit 3", None, &[])])
+            .await
+            .unwrap_err();
+        let (statuses, _logs) = drain(&mut rx);
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert!(
+            matches!(err, ExecutionError::NodeFailed { exit_code: 3, .. }),
+            "exit code must be preserved, got {err:?}",
+        );
+        assert!(kinds(&statuses).contains(&(JobEventKind::JobFailed as i32)));
+    }
+
+    #[tokio::test]
+    async fn a_dependent_node_is_skipped_when_its_dependency_fails() {
+        let root = tmp_root("skip");
+        let (tx, mut rx) = mpsc::channel(64);
+        let exec = Executor::new(tx, "job-skip".into(), root.clone(), false, vec![]);
+        let failing = script_node("build", &[], "exit 1", None, &[]);
+        let dependent = script_node("test", &["build"], "echo should-not-run", None, &[]);
+        let _ = exec.run(vec![failing, dependent]).await;
+        let (statuses, logs) = drain(&mut rx);
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert!(
+            kinds(&statuses).contains(&(JobEventKind::NodeSkipped as i32)),
+            "the dependent node must be skipped once its dependency fails",
+        );
+        assert!(
+            !logs.contains("should-not-run"),
+            "a skipped node must never execute; logs: {logs:?}",
+        );
+        assert!(kinds(&statuses).contains(&(JobEventKind::JobFailed as i32)));
+    }
 
     /// Regression: a workspace root that cannot be created (the bug was a
     /// missing/unwritable --workspace-root) must still bracket the job with
@@ -597,8 +808,7 @@ mod tests {
     #[tokio::test]
     async fn workspace_failure_still_reports_started_and_failed() {
         // A root nested under a regular FILE can never be created.
-        let blocker =
-            std::env::temp_dir().join(format!("scylla-exec-test-{}", std::process::id()));
+        let blocker = std::env::temp_dir().join(format!("scylla-exec-test-{}", std::process::id()));
         tokio::fs::write(&blocker, b"x").await.unwrap();
         let root = blocker.join("ws");
 

--- a/crates/scylla-core/src/application/secret/use_case.rs
+++ b/crates/scylla-core/src/application/secret/use_case.rs
@@ -74,8 +74,122 @@ where
         // Load first so we can authorize against the owning project.
         let secret = self.secret_repo.find_by_id(secret_id).await?;
         self.permission_service
-            .check(caller, Permission::DeleteSecret(secret.project_id().clone()))
+            .check(
+                caller,
+                Permission::DeleteSecret(secret.project_id().clone()),
+            )
             .await?;
         self.secret_repo.delete(secret_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::entities::UserId;
+    use crate::domain::errors::DomainError;
+    use crate::test_support::authz::{DenyingPermissionService, RecordingPermissionService};
+    use async_trait::async_trait;
+
+    /// Secret repo + cipher that panic if touched: proves a denied call never
+    /// reaches a side effect.
+    struct ForbiddenRepo;
+    #[async_trait]
+    impl SecretRepository for ForbiddenRepo {
+        async fn create(&self, _: &Secret) -> DomainResult<()> {
+            panic!("secret_repo.create must not run when authorization is denied")
+        }
+        async fn find_by_id(&self, _: &SecretId) -> DomainResult<Secret> {
+            panic!("secret_repo.find_by_id must not run when authorization is denied")
+        }
+        async fn list_by_project(&self, _: &ProjectId) -> DomainResult<Vec<Secret>> {
+            panic!("secret_repo.list_by_project must not run when authorization is denied")
+        }
+        async fn delete(&self, _: &SecretId) -> DomainResult<()> {
+            panic!("secret_repo.delete must not run when authorization is denied")
+        }
+    }
+    struct ForbiddenCipher;
+    impl SecretCipher for ForbiddenCipher {
+        fn encrypt(&self, _: &str) -> DomainResult<Vec<u8>> {
+            panic!("cipher.encrypt must not run when authorization is denied")
+        }
+        fn decrypt(&self, _: &[u8]) -> DomainResult<String> {
+            unreachable!()
+        }
+    }
+
+    /// A repo/cipher that accept writes, for the authorized happy path.
+    struct OkRepo;
+    #[async_trait]
+    impl SecretRepository for OkRepo {
+        async fn create(&self, _: &Secret) -> DomainResult<()> {
+            Ok(())
+        }
+        async fn find_by_id(&self, _: &SecretId) -> DomainResult<Secret> {
+            unimplemented!()
+        }
+        async fn list_by_project(&self, _: &ProjectId) -> DomainResult<Vec<Secret>> {
+            unimplemented!()
+        }
+        async fn delete(&self, _: &SecretId) -> DomainResult<()> {
+            unimplemented!()
+        }
+    }
+    struct OkCipher;
+    impl SecretCipher for OkCipher {
+        fn encrypt(&self, _: &str) -> DomainResult<Vec<u8>> {
+            Ok(vec![0xAA, 0xBB])
+        }
+        fn decrypt(&self, _: &[u8]) -> DomainResult<String> {
+            unimplemented!()
+        }
+    }
+
+    fn caller() -> CallerContext {
+        CallerContext::User(UserId::new("u1"))
+    }
+    fn project() -> ProjectId {
+        ProjectId::new("proj-1")
+    }
+    fn name() -> SecretName {
+        SecretName::new("DB_PASSWORD").unwrap()
+    }
+
+    #[tokio::test]
+    async fn create_authorizes_create_secret_on_the_target_project() {
+        let perms = Arc::new(RecordingPermissionService::new());
+        let uc = SecretUseCases::new(Arc::new(OkRepo), Arc::new(OkCipher), perms.clone());
+
+        uc.create(&caller(), project(), name(), "desc".into(), "value".into())
+            .await
+            .unwrap();
+
+        // The exact permission on the exact project must have been checked — a
+        // copy-paste against the wrong project id would fail here.
+        assert_eq!(
+            perms.permissions(),
+            vec![Permission::CreateSecret(project())]
+        );
+    }
+
+    #[tokio::test]
+    async fn create_denied_never_encrypts_or_persists() {
+        let uc = SecretUseCases::new(
+            Arc::new(ForbiddenRepo),
+            Arc::new(ForbiddenCipher),
+            Arc::new(DenyingPermissionService::new()),
+        );
+
+        let err = uc
+            .create(&caller(), project(), name(), "desc".into(), "value".into())
+            .await
+            .expect_err("a denied create must not succeed");
+
+        assert!(
+            matches!(err, DomainError::Forbidden(_)),
+            "denial must surface as Forbidden, got {err:?}",
+        );
+        // The panicking doubles prove authorization ran before any side effect.
     }
 }

--- a/crates/scylla-core/src/test_support/authz.rs
+++ b/crates/scylla-core/src/test_support/authz.rs
@@ -1,0 +1,74 @@
+//! Reusable `PermissionService` doubles for use-case tests.
+//!
+//! [`RecordingPermissionService`] allows everything and records each
+//! `(caller, permission)` it was asked to check, so a test can assert a use
+//! case authorized the *exact* permission on the *exact* resource before
+//! acting. [`DenyingPermissionService`] refuses everything, so a test can prove
+//! a use case checks authorization BEFORE touching repositories, ciphers, or
+//! any other collaborator (pair it with panicking stubs).
+
+use crate::application::authz::service::PermissionService;
+use crate::application::caller::CallerContext;
+use crate::domain::errors::{DomainError, DomainResult};
+use crate::domain::value_objects::permission::Permission;
+use async_trait::async_trait;
+use std::sync::Mutex;
+
+/// Allow-all `PermissionService` that records every check, in call order.
+#[derive(Default)]
+pub struct RecordingPermissionService {
+    checks: Mutex<Vec<(CallerContext, Permission)>>,
+}
+
+impl RecordingPermissionService {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Every `(caller, permission)` pair checked so far, in call order.
+    #[must_use]
+    pub fn checks(&self) -> Vec<(CallerContext, Permission)> {
+        self.checks.lock().unwrap().clone()
+    }
+
+    /// Just the permissions checked so far, in call order.
+    #[must_use]
+    pub fn permissions(&self) -> Vec<Permission> {
+        self.checks
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(_, p)| p.clone())
+            .collect()
+    }
+}
+
+#[async_trait]
+impl PermissionService for RecordingPermissionService {
+    async fn check(&self, caller: &CallerContext, permission: Permission) -> DomainResult<()> {
+        self.checks
+            .lock()
+            .unwrap()
+            .push((caller.clone(), permission));
+        Ok(())
+    }
+}
+
+/// Deny-all `PermissionService`: every check fails with `Forbidden`.
+#[derive(Default)]
+pub struct DenyingPermissionService;
+
+impl DenyingPermissionService {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl PermissionService for DenyingPermissionService {
+    async fn check(&self, _caller: &CallerContext, _permission: Permission) -> DomainResult<()> {
+        Err(DomainError::forbidden("denied by DenyingPermissionService"))
+    }
+}

--- a/crates/scylla-core/src/test_support/mod.rs
+++ b/crates/scylla-core/src/test_support/mod.rs
@@ -14,6 +14,7 @@
 //! let user = UserBuilder::new("alice").inactive().build();
 //! ```
 
+pub mod authz;
 pub mod job_logs;
 pub mod jobs;
 pub mod organizations;

--- a/crates/scylla-core/src/test_support/prelude.rs
+++ b/crates/scylla-core/src/test_support/prelude.rs
@@ -1,6 +1,7 @@
 //! One-stop import for test code. `use scylla_core::test_support::prelude::*;`
 //! brings every builder, shortcut and seeder into scope.
 
+pub use super::authz::*;
 pub use super::job_logs::*;
 pub use super::jobs::*;
 pub use super::organizations::*;


### PR DESCRIPTION
## What

Closes the two biggest test gaps from the review: the agent executor (which runs arbitrary user commands) and use-case authorization ordering.

## Why

- The executor is ~630 lines that spawn processes, clear the environment, redact secrets from logs, and enforce a workspace boundary, yet the only test never spawned a process. A refactor dropping `env_clear()` or flipping the masked flag would have leaked the agent's bearer token or raw secrets into persisted job logs with zero test failures.
- Authorization lives inside each use case (96 `permission_service.check` sites across 15 modules, 11 of them untested). Nothing verified a method checks the *right* permission on the *right* resource *before* acting, so a copy-paste against the wrong id would compile green and silently break tenant isolation, the #1 SaaS concern.

## How

**Executor tests** (in-process, real `sh` steps, `mpsc` receiver — same style as the existing regression test, no new deps):
- masked value echoed by a step is redacted (`***`) and the raw secret never reaches the log stream;
- `env_clear` isolation: a var in the agent's own environment does not leak into the job, while reserved `SCYLLA_*` context is injected (probe chosen dynamically from the agent env, so no `set_var`);
- a working dir escaping the workspace via a symlink is rejected with a terminal `JobFailed`;
- a non-zero exit maps to `NodeFailed { exit_code }`;
- a dependent node is skipped when its dependency fails (and never runs);
- `redact()` unit test.

**Reusable authz doubles** in `scylla_core::test_support::authz`:
- `RecordingPermissionService` (allow-all, records every `(caller, permission)`);
- `DenyingPermissionService` (deny-all);
- exemplar `SecretUseCases` tests: `create` authorizes `CreateSecret` on exactly the target project, and a denied `create` never reaches the cipher or repository (proven with panicking doubles).

## Tests / checks

Full workspace suite green (`12` agent + `25` api + `262` core), `clippy --workspace --all-targets --all-features` clean, changed files `rustfmt`-clean.

## Follow-up

The recording/deny doubles are the reusable enabler; extend them to the other high-risk use cases (pipeline run, job logs, grants) in a follow-up.
