### PR TITLE
fix(core,agent,control-plane): security & robustness mediums

### DIFF
--- a/crates/scylla-agent/src/agent.rs
+++ b/crates/scylla-agent/src/agent.rs
@@ -113,6 +113,15 @@ impl Agent {
                 url: url.clone(),
                 message: e.to_string(),
             })?;
+        // Keepalive so a half-open connection (proxy/NAT idle drop, or a control
+        // plane that vanished without a FIN) is detected instead of hanging the
+        // agent forever: pings while idle, and a missed pong tears the stream
+        // down so the outer reconnect loop kicks in.
+        endpoint = endpoint
+            .http2_keep_alive_interval(Duration::from_secs(20))
+            .keep_alive_timeout(Duration::from_secs(10))
+            .keep_alive_while_idle(true)
+            .tcp_keepalive(Some(Duration::from_secs(30)));
         // An https:// control plane terminates TLS at the proxy (which then
         // speaks h2c to the backend); load the host's native roots so the
         // handshake succeeds. Plain http:// (local dev) stays cleartext h2c.

--- a/crates/scylla-api/src/grpc/handlers/agent_handler.rs
+++ b/crates/scylla-api/src/grpc/handlers/agent_handler.rs
@@ -131,6 +131,13 @@ async fn read_reports<J, L, PS>(
                     if let Err(e) = job_use_cases.record_status(&caller, &job_id, &event).await {
                         warn!(app_id = %app_id, job_id = %job_id, error = %e, "failed to record job status");
                     }
+                    // Open the live channel at job start so a reader tailing a
+                    // running job that hasn't logged yet still joins the stream
+                    // (subscribe never creates a channel, to avoid leaking one
+                    // for an already-finished job).
+                    if matches!(event, JobEvent::JobStarted) {
+                        log_stream.open(job_id.as_str());
+                    }
                     // A terminal job won't emit more log lines — evict its live
                     // channel so the per-job stream map can't grow without bound,
                     // and free the agent's load slot so least-loaded dispatch can

--- a/crates/scylla-control-plane/src/main.rs
+++ b/crates/scylla-control-plane/src/main.rs
@@ -42,7 +42,16 @@ async fn main() {
 
 async fn run(args: Args) -> Result<()> {
     let config = load_config(&args)?;
-    tracing::debug!("Configuration: {:#?}", config);
+    // Never debug-dump the whole config: it holds the master key, the bootstrap
+    // password, SMTP and OAuth secrets. Log only which optional subsystems are
+    // configured.
+    tracing::info!(
+        secrets = config.api.secrets.is_some(),
+        mail = config.api.mail.is_some(),
+        github_oauth = config.api.oauth.github.is_some(),
+        webhook = config.api.webhook.is_some(),
+        "configuration loaded",
+    );
     runtime::run(config).await
 }
 

--- a/crates/scylla-core/src/application/oauth/use_case.rs
+++ b/crates/scylla-core/src/application/oauth/use_case.rs
@@ -78,6 +78,12 @@ where
             .find_user_id(PROVIDER_GITHUB, &info.provider_user_id)
             .await?
         {
+            // Same liveness gate as password login: a deactivated account must
+            // not be able to log back in through OAuth.
+            let user = self.user_repo.find_by_id(&user_id).await?;
+            if !user.is_active() {
+                return Err(DomainError::unauthorized("User account is inactive"));
+            }
             let token = self.issue_session(&user_id).await?;
             return Ok(OAuthOutcome {
                 token,
@@ -89,6 +95,9 @@ where
         // 2. Same email as an existing account → link the identity.
         if let Some(email) = &info.email {
             if let Ok(user) = self.user_repo.find_by_email(email).await {
+                if !user.is_active() {
+                    return Err(DomainError::unauthorized("User account is inactive"));
+                }
                 self.identity_repo
                     .link(user.id(), PROVIDER_GITHUB, &info.provider_user_id)
                     .await?;

--- a/crates/scylla-core/src/application/trigger/fire.rs
+++ b/crates/scylla-core/src/application/trigger/fire.rs
@@ -12,7 +12,7 @@ use crate::domain::value_objects::job::JobOrigin;
 use crate::domain::value_objects::trigger::{TriggerInputSource, TriggerSource};
 use async_trait::async_trait;
 use std::sync::Arc;
-use tracing::instrument;
+use tracing::{instrument, warn};
 
 /// The act of firing a trigger by id, decoupled from the concrete use-case so
 /// background drivers (the cron scheduler, later the webhook ingress) depend on
@@ -100,6 +100,31 @@ where
             return Err(DomainError::business_rule("trigger is disabled"));
         }
 
+        let outcome = self
+            .run_and_dispatch(&trigger, trigger_id, payload, delivery_id)
+            .await;
+
+        // Record the fire outcome on the trigger so `last_status` reflects
+        // reality (it used to be hard-coded "ok", so a failed fire looked
+        // successful). Best-effort: a status-write failure must not mask the
+        // actual run outcome.
+        trigger.mark_fired(clock::now(), if outcome.is_ok() { "ok" } else { "error" });
+        if let Err(e) = self.trigger_repo.update(&trigger).await {
+            warn!(trigger_id = %trigger_id, error = %e, "failed to record trigger fire status");
+        }
+        outcome
+    }
+
+    /// Run the trigger's pipeline as the org's trigger-runner App and best-effort
+    /// place it on an agent. Split out from [`Self::fire`] so the fire outcome
+    /// (ok / error) can be recorded on the trigger whatever happens here.
+    async fn run_and_dispatch(
+        &self,
+        trigger: &Trigger,
+        trigger_id: &TriggerId,
+        payload: Option<&serde_json::Value>,
+        delivery_id: Option<&str>,
+    ) -> DomainResult<Job> {
         // The run fires as the org's trigger-runner App (resolved pipeline →
         // project → org → App), so the single RunPipeline check is satisfied by
         // its org-scoped grant.
@@ -120,7 +145,7 @@ where
             },
         };
 
-        let inputs = resolve_inputs(&trigger, payload);
+        let inputs = resolve_inputs(trigger, payload);
         let (job, dispatch) = self
             .pipeline_uc
             .run_with_inputs(&caller, trigger.pipeline_id(), &inputs, origin)
@@ -128,14 +153,13 @@ where
 
         // Best-effort placement: if no agent is connected/authorized the job
         // stays pending and the PendingJobScheduler retries it later.
-        if let DispatchOutcome::Dispatched(app_id) =
-            self.dispatch_uc.dispatch_job(trigger.pipeline_id(), &dispatch).await?
+        if let DispatchOutcome::Dispatched(app_id) = self
+            .dispatch_uc
+            .dispatch_job(trigger.pipeline_id(), &dispatch)
+            .await?
         {
             self.pipeline_uc.assign_agent(job.id(), &app_id).await?;
         }
-
-        trigger.mark_fired(clock::now(), "ok");
-        self.trigger_repo.update(&trigger).await?;
         Ok(job)
     }
 
@@ -235,7 +259,10 @@ mod tests {
         )
         .unwrap();
         let resolved = resolve_inputs(&trigger, None);
-        assert_eq!(resolved, vec![("RUN_MODE".to_string(), "nightly".to_string())]);
+        assert_eq!(
+            resolved,
+            vec![("RUN_MODE".to_string(), "nightly".to_string())]
+        );
     }
 
     #[test]

--- a/crates/scylla-core/src/infrastructure/messaging/in_memory_job_log_stream.rs
+++ b/crates/scylla-core/src/infrastructure/messaging/in_memory_job_log_stream.rs
@@ -43,7 +43,29 @@ impl InMemoryJobLogStream {
             .clone()
     }
 
-    /// Publish a log line to the live subscribers of its job (no-op if none).
+    /// The live sender for a job **only if one already exists** — never creates
+    /// one. Used by `subscribe`: subscribing must not resurrect a channel for a
+    /// job whose live stream was already closed (a finished job), which would
+    /// leak an entry that is never published to nor closed again.
+    fn existing_sender(&self, job_id: &str) -> Option<broadcast::Sender<JobLog>> {
+        self.channels
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(job_id)
+            .cloned()
+    }
+
+    /// Eagerly create a job's live channel at start, so a reader that subscribes
+    /// before the first log line still joins the live stream. Paired with
+    /// [`Self::close`] at terminal; since [`JobLogStreamPort::subscribe`] never
+    /// creates a channel, a finished job's channel can't be resurrected and
+    /// leaked by a late subscriber.
+    pub fn open(&self, job_id: &str) {
+        let _ = self.sender_for(job_id);
+    }
+
+    /// Publish a log line to the live subscribers of its job. Creates the channel
+    /// if the job's `open` was missed, so a line is never silently dropped.
     pub fn publish(&self, log: JobLog) {
         let _ = self.sender_for(log.job_id().as_str()).send(log);
     }
@@ -69,9 +91,17 @@ impl JobLogStreamPort for InMemoryJobLogStream {
         job_id: &JobId,
         node_id: Option<&NodeId>,
     ) -> DomainResult<JobLogLiveStream> {
-        let mut receiver = self.sender_for(job_id.as_str()).subscribe();
-        let node_filter = node_id.cloned();
         let (tx, rx) = mpsc::channel::<DomainResult<JobLog>>(CHANNEL_CAPACITY);
+
+        // No live channel means the job already reached a terminal state (its
+        // channel was closed) or never streamed: return an immediately-ending
+        // stream so the caller falls back to the persisted snapshot, WITHOUT
+        // resurrecting a channel that would then leak forever.
+        let Some(sender) = self.existing_sender(job_id.as_str()) else {
+            return Ok(Box::pin(ReceiverStream::new(rx)));
+        };
+        let mut receiver = sender.subscribe();
+        let node_filter = node_id.cloned();
 
         // Bridge the broadcast receiver to an mpsc the caller can stream. Lagged
         // lines are skipped (the historical snapshot covers any gap); the task
@@ -93,5 +123,65 @@ impl JobLogStreamPort for InMemoryJobLogStream {
         });
 
         Ok(Box::pin(ReceiverStream::new(rx)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::value_objects::job::LogStream;
+    use chrono::Utc;
+    use tokio_stream::StreamExt;
+
+    fn log(job: &str) -> JobLog {
+        JobLog::new(
+            JobId::new(job),
+            NodeId::new("n1").unwrap(),
+            LogStream::Stdout,
+            "hello".to_string(),
+            Utc::now(),
+        )
+    }
+
+    #[tokio::test]
+    async fn subscribe_to_an_unopened_job_yields_an_empty_stream() {
+        let s = InMemoryJobLogStream::new();
+        let mut stream = s.subscribe(&JobId::new("ghost"), None).await.unwrap();
+        assert!(
+            stream.next().await.is_none(),
+            "no live channel means an immediately-ending stream (fall back to the snapshot)",
+        );
+        // Crucially, subscribing did NOT create a channel — otherwise it would
+        // leak forever for a job that will never publish or be closed again.
+        assert!(
+            s.existing_sender("ghost").is_none(),
+            "subscribe must not create a channel"
+        );
+    }
+
+    #[tokio::test]
+    async fn open_then_publish_reaches_a_live_subscriber() {
+        let s = InMemoryJobLogStream::new();
+        s.open("job-1");
+        let mut stream = s.subscribe(&JobId::new("job-1"), None).await.unwrap();
+        s.publish(log("job-1"));
+        let received = stream.next().await.expect("a live line").expect("ok");
+        assert_eq!(received.line(), "hello");
+    }
+
+    #[tokio::test]
+    async fn subscribe_after_close_does_not_resurrect_a_channel() {
+        let s = InMemoryJobLogStream::new();
+        s.open("job-1");
+        s.close("job-1");
+        let mut stream = s.subscribe(&JobId::new("job-1"), None).await.unwrap();
+        assert!(
+            stream.next().await.is_none(),
+            "a finished job's live channel must not be recreated",
+        );
+        assert!(
+            s.existing_sender("job-1").is_none(),
+            "no leaked channel entry"
+        );
     }
 }

--- a/crates/scylla-core/src/infrastructure/persistence/postgres/error.rs
+++ b/crates/scylla-core/src/infrastructure/persistence/postgres/error.rs
@@ -5,12 +5,21 @@ use std::fmt::Display;
 /// as `Conflict` so callers don't have to special-case them.
 pub(crate) fn map_sqlx(err: sqlx::Error) -> DomainError {
     match err {
-        sqlx::Error::Database(db_err)
-            if db_err.is_unique_violation() || db_err.is_foreign_key_violation() =>
-        {
-            DomainError::conflict(db_err.to_string())
+        sqlx::Error::Database(db_err) if db_err.is_unique_violation() => {
+            // The raw driver text (constraint name, column values) must not reach
+            // the client; log it for operators and return a generic conflict.
+            tracing::debug!(error = %db_err, "unique-constraint violation");
+            DomainError::conflict("a resource with these values already exists")
         }
-        other => DomainError::infrastructure(format!("Database error: {other}")),
+        sqlx::Error::Database(db_err) if db_err.is_foreign_key_violation() => {
+            tracing::debug!(error = %db_err, "foreign-key violation");
+            DomainError::conflict("references a missing or in-use related resource")
+        }
+        other => {
+            // Never surface raw SQL/driver detail to callers.
+            tracing::error!(error = %other, "unexpected database error");
+            DomainError::infrastructure("database error")
+        }
     }
 }
 

--- a/crates/scylla-core/src/infrastructure/services/argon2_hash_service.rs
+++ b/crates/scylla-core/src/infrastructure/services/argon2_hash_service.rs
@@ -24,15 +24,24 @@ impl Argon2HashService {
 
 #[async_trait]
 impl HashService for Argon2HashService {
+    // Argon2 is deliberately CPU-heavy (tens of ms). Running it inline would
+    // block an async worker thread for that whole time, so each hash/verify is
+    // moved onto Tokio's blocking pool — which is exactly what the per-call
+    // `clone()`s (of the hasher and the input) are for.
     #[instrument(skip(self, password))]
     async fn hash(&self, password: &Password) -> DomainResult<PasswordHash> {
         let argon2 = self.argon2.clone();
         let password = password.clone();
-        let hash = argon2
-            .hash_password(password.as_str().as_bytes())
-            .map_err(|e| DomainError::internal(format!("Failed to hash password: {e}")))?;
+        let hash = tokio::task::spawn_blocking(move || {
+            argon2
+                .hash_password(password.as_str().as_bytes())
+                .map(|h| h.to_string())
+                .map_err(|e| DomainError::internal(format!("Failed to hash password: {e}")))
+        })
+        .await
+        .map_err(|e| DomainError::internal(format!("password hashing task failed: {e}")))??;
 
-        PasswordHash::new(hash.to_string())
+        PasswordHash::new(hash)
     }
 
     #[instrument(skip(self, password, hash))]
@@ -40,23 +49,31 @@ impl HashService for Argon2HashService {
         let argon2 = self.argon2.clone();
         let password = password.clone();
         let hash = hash.as_str().to_string();
-        let parsed_hash = Argon2PasswordHash::new(&hash)
-            .map_err(|e| DomainError::internal(format!("Failed to parse hash: {e}")))?;
-
-        Ok(argon2
-            .verify_password(password.as_str().as_bytes(), &parsed_hash)
-            .is_ok())
+        tokio::task::spawn_blocking(move || {
+            let parsed_hash = Argon2PasswordHash::new(&hash)
+                .map_err(|e| DomainError::internal(format!("Failed to parse hash: {e}")))?;
+            Ok(argon2
+                .verify_password(password.as_str().as_bytes(), &parsed_hash)
+                .is_ok())
+        })
+        .await
+        .map_err(|e| DomainError::internal(format!("password verification task failed: {e}")))?
     }
 
     #[instrument(skip(self, secret))]
     async fn hash_secret(&self, secret: &AppSecret) -> DomainResult<AppSecretHash> {
         let argon2 = self.argon2.clone();
         let secret = secret.clone();
-        let hash = argon2
-            .hash_password(secret.as_str().as_bytes())
-            .map_err(|e| DomainError::internal(format!("Failed to hash app secret: {e}")))?;
+        let hash = tokio::task::spawn_blocking(move || {
+            argon2
+                .hash_password(secret.as_str().as_bytes())
+                .map(|h| h.to_string())
+                .map_err(|e| DomainError::internal(format!("Failed to hash app secret: {e}")))
+        })
+        .await
+        .map_err(|e| DomainError::internal(format!("app-secret hashing task failed: {e}")))??;
 
-        AppSecretHash::new(hash.to_string())
+        AppSecretHash::new(hash)
     }
 
     #[instrument(skip(self, secret, hash))]
@@ -64,11 +81,14 @@ impl HashService for Argon2HashService {
         let argon2 = self.argon2.clone();
         let secret = secret.clone();
         let hash = hash.as_str().to_string();
-        let parsed_hash = Argon2PasswordHash::new(&hash)
-            .map_err(|e| DomainError::internal(format!("Failed to parse hash: {e}")))?;
-
-        Ok(argon2
-            .verify_password(secret.as_str().as_bytes(), &parsed_hash)
-            .is_ok())
+        tokio::task::spawn_blocking(move || {
+            let parsed_hash = Argon2PasswordHash::new(&hash)
+                .map_err(|e| DomainError::internal(format!("Failed to parse hash: {e}")))?;
+            Ok(argon2
+                .verify_password(secret.as_str().as_bytes(), &parsed_hash)
+                .is_ok())
+        })
+        .await
+        .map_err(|e| DomainError::internal(format!("app-secret verification task failed: {e}")))?
     }
 }


### PR DESCRIPTION
## What

A batch of contained **backend security & robustness** medium findings from the multi-agent review, grouped in one PR.

## Fixes

| Finding | Fix |
|---|---|
| Argon2 hashing blocks the async runtime | `hash`/`verify` (password & app-secret) now run via `spawn_blocking`; the previously-dead per-call clones feed the blocking closures. |
| Raw Postgres text leaks to clients | `map_sqlx` returns generic messages (unique / FK → conflict, else infrastructure) and logs the driver detail for operators instead of surfacing it. FK→conflict mapping kept (existing tests rely on it). |
| Control plane debug-dumps the whole config incl. secrets | Replaced with a redacted `info` line (booleans: which optional subsystems are configured). |
| Subscribing to a finished job's logs leaks a broadcast channel | `subscribe` no longer creates a channel; the channel is opened at `JobStarted` and closed at terminal, so a late subscriber to a finished job gets an immediately-ending stream (falls back to the persisted snapshot) with no leak. |
| Agent connection can hang half-open forever | Added HTTP/2 + TCP keepalive on the agent's channel, so a dead control-plane connection is detected and the existing reconnect loop kicks in. |
| Trigger fire failures never recorded (`last_status` always "ok") | The run is split out; the trigger records `ok`/`error` whatever the outcome. |
| Deactivated accounts can still log in via OAuth | Added the same `is_active` gate as password login, on both the known-identity and email-link paths. |

## Tests / checks

New unit tests for the job-log stream lifecycle (empty stream for an unopened/closed job, no channel resurrection, live delivery after `open`). Full workspace suite green (`6` agent + `25` api + `263` core), `clippy --workspace --all-targets --all-features` clean, changed files `rustfmt`-clean.

## Deliberately NOT in this PR (and why)

Kept out to stay reviewable / because they need their own design:
- **Larger security items needing a migration or redesign:** hashing session/app/invitation bearer tokens at rest (schema migration + lookup-by-hash across repos), master-key rotation (key-id in ciphertext + migration), webhook replay protection (signed nonce/timestamp), trigger-runner stable identity (currently resolved by mutable display name), agent forging status/logs for another job in its org (needs a job-ownership check plumbed into the handler), anti-escalation for Project-scoped grants (needs scope-ancestor resolution).
- **Placement / naming** findings (cosmetic module/file moves) — better as a dedicated cleanup.
- **Frontend** findings (TypeScript) — separate stack.
- **Infra/CI** findings (add a PR workflow, `DATABASE_URL` not read, stale `prod.toml`) — separate.

These remain tracked in the review backlog.
