### PR TITLE
feat(authz): add GetMyPermissions rpc

### DIFF
--- a/apps/frontend/src/modules/features/permission/di/permisson.module.ts
+++ b/apps/frontend/src/modules/features/permission/di/permisson.module.ts
@@ -6,6 +6,7 @@ import { CreateRoleUseCase } from '@/modules/features/permission/domain/usecases
 import { UpdateRoleUseCase } from '@/modules/features/permission/domain/usecases/update-role.use-case.ts';
 import { DeleteRoleUseCase } from '@/modules/features/permission/domain/usecases/delete-role.use-case.ts';
 import { GetEffectivePermissionsUseCase } from '@/modules/features/permission/domain/usecases/get-effective-permissions.use-case.ts';
+import { GetMyPermissionsUseCase } from '@/modules/features/permission/domain/usecases/get-my-permissions.use-case.ts';
 import { ListGrantsUseCase } from '@/modules/features/permission/domain/usecases/list-grants.use-case.ts';
 import { CreateGrantUseCase } from '@/modules/features/permission/domain/usecases/create-grant.use-case.ts';
 import { RevokeGrantUseCase } from '@/modules/features/permission/domain/usecases/revoke-grant.use-case.ts';
@@ -22,6 +23,7 @@ export const PermissonModule = {
     updateRole: new UpdateRoleUseCase(repository),
     deleteRole: new DeleteRoleUseCase(repository),
     getEffectivePermissions: new GetEffectivePermissionsUseCase(repository),
+    getMyPermissions: new GetMyPermissionsUseCase(repository),
     listGrants: new ListGrantsUseCase(repository),
     createGrant: new CreateGrantUseCase(repository),
     revokeGrant: new RevokeGrantUseCase(repository),

--- a/apps/frontend/src/modules/features/permission/domain/repository/permission.repository.ts
+++ b/apps/frontend/src/modules/features/permission/domain/repository/permission.repository.ts
@@ -44,6 +44,8 @@ export interface PermissionRepository {
   getEffectivePermissions(
     principal: PrincipalEntity,
   ): Promise<ScyllaResult<EffectivePermissionsEntity>>;
+  /** The signed-in caller's own access. Needs no permission, unlike the above. */
+  getMyPermissions(): Promise<ScyllaResult<EffectivePermissionsEntity>>;
 
   // ── Grants (principal holds role|permission within scope) ──────────────────
   listGrants(scope?: PermissionScope, scopeId?: string): Promise<ScyllaResult<GrantEntity[]>>;

--- a/apps/frontend/src/modules/features/permission/domain/usecases/get-my-permissions.use-case.ts
+++ b/apps/frontend/src/modules/features/permission/domain/usecases/get-my-permissions.use-case.ts
@@ -1,0 +1,16 @@
+import type { EffectivePermissionsEntity } from '@/modules/features/permission/domain/entities/effective-permissions.entity.ts';
+import type { PermissionRepository } from '@/modules/features/permission/domain/repository/permission.repository.ts';
+import type { ScyllaResult } from '@shared/utils/scylla-result.ts';
+
+/**
+ * The signed-in caller's own access. Takes no principal: the server derives it
+ * from the session, so asking for someone else's is not expressible here. Use
+ * {@link GetEffectivePermissionsUseCase} for the admin view over others.
+ */
+export class GetMyPermissionsUseCase {
+  constructor(private readonly _repository: PermissionRepository) {}
+
+  public execute(): Promise<ScyllaResult<EffectivePermissionsEntity>> {
+    return this._repository.getMyPermissions();
+  }
+}

--- a/apps/frontend/src/modules/features/permission/infrastructure/data/grpc-permission-remote.data-source.ts
+++ b/apps/frontend/src/modules/features/permission/infrastructure/data/grpc-permission-remote.data-source.ts
@@ -88,6 +88,13 @@ export class GrpcPermissionRemoteDataSource implements PermissionDataSource {
     );
   }
 
+  public getMyPermissions(): Promise<ScyllaResult<EffectiveScope[]>> {
+    return ScyllaResult.tryAsync(
+      async () => (await this._roles.getMyPermissions({})).response.scopes,
+      'Failed to fetch your own permissions.',
+    );
+  }
+
   public listGrants(scope?: ScopeRef): Promise<ScyllaResult<Grant[]>> {
     return ScyllaResult.tryAsync(
       async () => (await this._grants.listGrants({ scope })).response.grants,

--- a/apps/frontend/src/modules/features/permission/infrastructure/repository/data-sources/permission.data-source.ts
+++ b/apps/frontend/src/modules/features/permission/infrastructure/repository/data-sources/permission.data-source.ts
@@ -34,6 +34,7 @@ export interface PermissionDataSource {
 
   // ── Introspection ──────────────────────────────────────────────────────────
   getEffectivePermissions(principal: PrincipalRef): Promise<ScyllaResult<EffectiveScope[]>>;
+  getMyPermissions(): Promise<ScyllaResult<EffectiveScope[]>>;
 
   // ── Grants ─────────────────────────────────────────────────────────────────
   listGrants(scope?: ScopeRef): Promise<ScyllaResult<Grant[]>>;

--- a/apps/frontend/src/modules/features/permission/infrastructure/repository/default-permission.repository.ts
+++ b/apps/frontend/src/modules/features/permission/infrastructure/repository/default-permission.repository.ts
@@ -65,6 +65,10 @@ export class DefaultPermissionRepository implements PermissionRepository {
     ).map(GrpcEffectivePermissionsMapper.toDomain);
   }
 
+  public async getMyPermissions(): Promise<ScyllaResult<EffectivePermissionsEntity>> {
+    return (await this._dataSource.getMyPermissions()).map(GrpcEffectivePermissionsMapper.toDomain);
+  }
+
   // ── Grants ─────────────────────────────────────────────────────────────────
 
   public async listGrants(

--- a/apps/frontend/src/modules/features/permission/presentation/hooks/use-my-permissions.ts
+++ b/apps/frontend/src/modules/features/permission/presentation/hooks/use-my-permissions.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { useDependencies } from '@core/presentation/hooks/use-dependencies.ts';
+
+const MY_PERMISSIONS_QUERY_KEY = 'authz-my-permissions';
+
+/**
+ * The signed-in user's own access, grouped by the scope each grant binds to.
+ * A query rather than a mutation: it describes the current session and is read
+ * on mount, unlike the admin lookup in `use-effective-permissions.ts`, which
+ * runs on form submit for an arbitrary principal.
+ *
+ * Grants only change through an admin action elsewhere, so the result is cached
+ * for the session; invalidate `MY_PERMISSIONS_QUERY_KEY` if the app ever needs
+ * to reflect a mid-session change.
+ */
+export function useMyPermissions() {
+  const { authz } = useDependencies();
+
+  return useQuery({
+    queryKey: [MY_PERMISSIONS_QUERY_KEY],
+    queryFn: async () => (await authz.getMyPermissions.execute()).unwrap(),
+  });
+}

--- a/crates/scylla-api/src/grpc/handlers/role_handler.rs
+++ b/crates/scylla-api/src/grpc/handlers/role_handler.rs
@@ -12,10 +12,10 @@ use scylla_core::application::{
 use scylla_protocol::authz::v1::{
     Access, AuthzAction, CreateRoleRequest, CreateRoleResponse, DeleteRoleRequest,
     DeleteRoleResponse, EffectiveScope as ProtoEffectiveScope, GetEffectivePermissionsRequest,
-    GetEffectivePermissionsResponse, GetRoleRequest, GetRoleResponse, ListAuthzVocabularyRequest,
-    ListAuthzVocabularyResponse, ListRolesRequest, ListRolesResponse, Permission,
-    Role as ProtoRole, UpdateRoleRequest, UpdateRoleResponse, access, role,
-    role_service_server::RoleService,
+    GetEffectivePermissionsResponse, GetMyPermissionsRequest, GetMyPermissionsResponse,
+    GetRoleRequest, GetRoleResponse, ListAuthzVocabularyRequest, ListAuthzVocabularyResponse,
+    ListRolesRequest, ListRolesResponse, Permission, Role as ProtoRole, UpdateRoleRequest,
+    UpdateRoleResponse, access, role, role_service_server::RoleService,
 };
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
@@ -146,6 +146,23 @@ impl<
             .map_err(domain_error_to_status)?;
 
         Ok(Response::new(GetEffectivePermissionsResponse {
+            scopes: scopes.iter().map(effective_scope_to_proto).collect(),
+        }))
+    }
+
+    async fn get_my_permissions(
+        &self,
+        request: Request<GetMyPermissionsRequest>,
+    ) -> Result<Response<GetMyPermissionsResponse>, Status> {
+        let caller = caller!(request);
+
+        let scopes = self
+            .use_cases
+            .my_permissions(&caller)
+            .await
+            .map_err(domain_error_to_status)?;
+
+        Ok(Response::new(GetMyPermissionsResponse {
             scopes: scopes.iter().map(effective_scope_to_proto).collect(),
         }))
     }

--- a/crates/scylla-core/src/application/authz/grant/mod.rs
+++ b/crates/scylla-core/src/application/authz/grant/mod.rs
@@ -1,4 +1,5 @@
 use crate::application::authz::role::RoleRepository;
+use crate::application::caller::CallerContext;
 use crate::domain::entities::{AppId, OrganizationId, ProjectId, UserId};
 use crate::domain::errors::{DomainError, DomainResult};
 use crate::domain::value_objects::role::RoleName;
@@ -250,6 +251,18 @@ pub enum Principal {
 }
 
 impl Principal {
+    /// The principal a caller acts as, or `None` when the caller is not one:
+    /// an internal `Service` acts as the system (permitted by a static Cedar
+    /// policy, it holds no grants), and `Anonymous` is nobody.
+    #[must_use]
+    pub fn from_caller(caller: &CallerContext) -> Option<Self> {
+        match caller {
+            CallerContext::User(id) => Some(Self::User(id.clone())),
+            CallerContext::App(id) => Some(Self::App(id.clone())),
+            CallerContext::Service(_) | CallerContext::Anonymous => None,
+        }
+    }
+
     /// Persistence discriminant — the `principal_kind` column value.
     #[must_use]
     pub fn kind(&self) -> &'static str {

--- a/crates/scylla-core/src/application/authz/grant/use_case.rs
+++ b/crates/scylla-core/src/application/authz/grant/use_case.rs
@@ -132,11 +132,9 @@ impl<G: GrantRepository, PC: PolicyControl, PS: PermissionService> GrantUseCases
     /// not subset-checked yet (smallest blast radius) — they stay gated by
     /// `manageProjectGrants`.
     async fn check_no_escalation(&self, caller: &CallerContext, grant: &Grant) -> DomainResult<()> {
-        let principal = match caller {
-            CallerContext::User(id) => Principal::User(id.clone()),
-            CallerContext::App(id) => Principal::App(id.clone()),
-            // Services act as the system; Anonymous is already denied upstream.
-            CallerContext::Service(_) | CallerContext::Anonymous => return Ok(()),
+        // Services act as the system; Anonymous is already denied upstream.
+        let Some(principal) = Principal::from_caller(caller) else {
+            return Ok(());
         };
         if matches!(grant.scope, Scope::Project(_)) {
             return Ok(());

--- a/crates/scylla-core/src/application/authz/role.rs
+++ b/crates/scylla-core/src/application/authz/role.rs
@@ -287,13 +287,10 @@ where
         self.policy_control.reload().await
     }
 
-    /// Resolve a principal's effective permissions, grouped by the scope each
-    /// grant binds to (each grant's role expanded to its permission set).
-    /// Powers the "what can this principal do" matrix. Gated by `manageGrants`.
-    ///
-    /// Note: this returns grants AS BOUND per scope; it does not expand scope
-    /// inheritance (a System grant is reported at System, not re-listed under
-    /// every org/project beneath it).
+    /// Resolve *another* principal's effective permissions, grouped by the scope
+    /// each grant binds to. Powers the admin "what can this principal do" matrix,
+    /// so it is gated by `manageSystemGrants`. To read your own, call
+    /// [`Self::my_permissions`], which needs no permission at all.
     #[instrument(skip(self, caller))]
     pub async fn effective_permissions(
         &self,
@@ -303,7 +300,41 @@ where
         self.permission_service
             .check(caller, Permission::ManageSystemGrants)
             .await?;
+        self.resolve_effective_permissions(principal).await
+    }
 
+    /// The caller's own effective permissions. Deliberately takes no principal:
+    /// there is nothing to authorize, because the only readable principal is the
+    /// caller itself, and that is enforced by the shape of the call rather than
+    /// by a check on its argument. Backs the "my access" view and any client-side
+    /// decision about what to offer the current user.
+    ///
+    /// An internal `Service` caller acts as the system and holds no grants, so it
+    /// has nothing to report; `Anonymous` never reaches here (the transport
+    /// rejects it first). Both are refused rather than answered with an empty
+    /// list, which would read as "you have no permissions".
+    #[instrument(skip(self, caller))]
+    pub async fn my_permissions(
+        &self,
+        caller: &CallerContext,
+    ) -> DomainResult<Vec<EffectiveScope>> {
+        let principal = Principal::from_caller(caller).ok_or_else(|| {
+            DomainError::Forbidden("this caller is not a principal that holds grants".to_string())
+        })?;
+        self.resolve_effective_permissions(&principal).await
+    }
+
+    /// Group a principal's grants by scope and expand each grant's role to its
+    /// permission set. Shared by both entry points above, which differ only in
+    /// how they establish *whose* permissions may be read.
+    ///
+    /// Note: this returns grants AS BOUND per scope; it does not expand scope
+    /// inheritance (a System grant is reported at System, not re-listed under
+    /// every org/project beneath it).
+    async fn resolve_effective_permissions(
+        &self,
+        principal: &Principal,
+    ) -> DomainResult<Vec<EffectiveScope>> {
         let role_perms: HashMap<String, Vec<String>> = self
             .role_repo
             .list_all()

--- a/crates/scylla-core/src/infrastructure/persistence/postgres/roles/mod.rs
+++ b/crates/scylla-core/src/infrastructure/persistence/postgres/roles/mod.rs
@@ -317,4 +317,73 @@ mod tests {
             .expect("org o1 scope");
         assert_eq!(org.permissions, vec!["deleteJob".to_string()]);
     }
+
+    /// Reading your own access needs no permission, while reading someone else's
+    /// still requires `manageSystemGrants`. Both run against a permission service
+    /// that denies everything, so the split is what is under test, not the stub.
+    #[sqlx::test(migrations = "../../migrations")]
+    async fn my_permissions_needs_no_permission_unlike_the_admin_view(pool: PgPool) {
+        use crate::application::PermissionService;
+        use crate::application::authz::policy::PolicyControl;
+        use crate::application::authz::{Principal, RoleUseCases, Scope};
+        use crate::application::caller::{CallerContext, ServiceIdentity};
+        use crate::domain::entities::UserId;
+        use crate::domain::errors::{DomainError, DomainResult};
+        use crate::domain::value_objects::permission::Permission;
+        use crate::infrastructure::persistence::postgres::PgGrantRepository;
+        use std::sync::Arc;
+
+        struct DenyAll;
+        #[async_trait::async_trait]
+        impl PermissionService for DenyAll {
+            async fn check(&self, _c: &CallerContext, _p: Permission) -> DomainResult<()> {
+                Err(DomainError::Forbidden("denied".to_string()))
+            }
+        }
+        struct NoopPolicy;
+        #[async_trait::async_trait]
+        impl PolicyControl for NoopPolicy {
+            async fn reload(&self) -> DomainResult<()> {
+                Ok(())
+            }
+        }
+
+        sqlx::query!(
+            "INSERT INTO grants (id, principal_kind, principal_id, role_id, scope_kind, scope_id) \
+             VALUES ('g1', 'user', 'alice', 'organization-admin', 'organization', 'o1')"
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let uc = RoleUseCases::new(
+            Arc::new(PgRoleRepository::new(pool.clone())),
+            Arc::new(PgGrantRepository::new(pool)),
+            Arc::new(DenyAll),
+            Arc::new(NoopPolicy),
+        );
+
+        // Alice reads her own access even though every permission check fails.
+        let alice = CallerContext::User(UserId::new("alice"));
+        let scopes = uc.my_permissions(&alice).await.expect("own permissions");
+        assert_eq!(scopes.len(), 1);
+        assert!(matches!(&scopes[0].scope, Scope::Organization(o) if o.as_str() == "o1"));
+        assert!(scopes[0].full_control, "organization-admin confers '*'");
+
+        // A user with no grants gets an empty list, not an error.
+        let bob = CallerContext::User(UserId::new("bob"));
+        assert!(uc.my_permissions(&bob).await.unwrap().is_empty());
+
+        // The admin view over another principal is still gated.
+        assert!(
+            uc.effective_permissions(&alice, &Principal::User(UserId::new("bob")))
+                .await
+                .is_err(),
+            "reading another principal must still require manageSystemGrants",
+        );
+
+        // A service acts as the system and holds no grants: refused, not empty.
+        let service = CallerContext::Service(ServiceIdentity::recorder());
+        assert!(uc.my_permissions(&service).await.is_err());
+    }
 }

--- a/crates/scylla-protocol/proto/scylla/authz/v1/role.proto
+++ b/crates/scylla-protocol/proto/scylla/authz/v1/role.proto
@@ -16,9 +16,15 @@ service RoleService {
   rpc DeleteRole(DeleteRoleRequest) returns (DeleteRoleResponse);
   rpc ListRoles(ListRolesRequest) returns (ListRolesResponse);
   // "What can this principal do" — the principal's resolved permissions grouped
-  // by the scope each grant binds to. Backs a permission matrix. Requires
-  // `manageSystemGrants`.
+  // by the scope each grant binds to. Backs an admin permission matrix over
+  // *other* principals, so it requires `manageSystemGrants`. To read your own,
+  // call GetMyPermissions.
   rpc GetEffectivePermissions(GetEffectivePermissionsRequest) returns (GetEffectivePermissionsResponse);
+  // The caller's own resolved permissions, same shape as above. Takes no
+  // principal on purpose: reading your own access needs no permission, and
+  // asking for someone else's is unrepresentable rather than rejected at
+  // runtime. Backs the "my access" view and client-side affordances.
+  rpc GetMyPermissions(GetMyPermissionsRequest) returns (GetMyPermissionsResponse);
   // The authorization vocabulary a role may reference: every permission, with
   // the narrowest scope kind it is coherent at. Read-only — lets a role editor
   // enumerate real permissions instead of guessing names.
@@ -91,6 +97,10 @@ message EffectiveScope {
 }
 
 message GetEffectivePermissionsResponse { repeated EffectiveScope scopes = 1; }
+
+message GetMyPermissionsRequest {}
+
+message GetMyPermissionsResponse { repeated EffectiveScope scopes = 1; }
 
 message ListAuthzVocabularyRequest {}
 


### PR DESCRIPTION
> Stacked on #148. Review that one first; this branch only adds the commit on top.

## Why

Reading your own access required `manageSystemGrants`, so nobody but a system admin could see what they hold. `GetEffectivePermissions` was the only way in, and it is an admin tool.

## Approach

A separate RPC that takes no principal at all. The server derives it from the session, so asking for someone else's access is unrepresentable rather than rejected at runtime.

The alternative was to exempt the caller inside `GetEffectivePermissions` (three lines, no proto change). It was rejected because the authorization rule would then depend on an argument: invisible from the proto, inexpressible in Cedar, and the self path would write nothing to the audit log.

`GetEffectivePermissions` keeps its guard and stays the admin view over other principals. Both entry points share `resolve_effective_permissions`, so they can never disagree on what a principal holds.

A `Service` caller acts as the system and holds no grants; `Anonymous` never reaches the handler (the interceptor rejects it first). Both are refused rather than answered with an empty list, which would read as "you have no permissions". `Principal::from_caller` carries that rule and replaces the duplicated match in `check_no_escalation`.

## Frontend

Full chain: data source, repository, `GetMyPermissionsUseCase`, DI registration, and a `useMyPermissions` hook. It is a `useQuery`, read on mount and cached, unlike the existing admin hook which is a mutation fired on form submit for an arbitrary principal. No screen consumes it yet.

## Test

`my_permissions_needs_no_permission_unlike_the_admin_view` runs against a permission service that denies everything: Alice still reads her own access, a user with no grants gets an empty list rather than an error, the admin view over another principal still fails, and a `Service` caller is refused.

## Not done here

An organization admin still cannot see the effective permissions of their own members, which is arguably their job. That needs per-scope filtering of the result and is a separate change; this PR deliberately does not touch the admin path.