### PR TITLE
fix(authz): require project membership for project grants

### DIFF
--- a/crates/scylla-core/src/application/authz/grant/use_case.rs
+++ b/crates/scylla-core/src/application/authz/grant/use_case.rs
@@ -6,7 +6,7 @@ use crate::application::authz::role::{FULL_CONTROL, RoleRepository};
 use crate::application::authz::service::PermissionService;
 use crate::application::caller::CallerContext;
 use crate::domain::errors::{DomainError, DomainResult};
-use crate::domain::value_objects::permission::{Permission, ResourceRef};
+use crate::domain::value_objects::permission::Permission;
 use crate::domain::value_objects::role::RoleName;
 use derive_more::Constructor;
 use std::collections::{BTreeSet, HashMap};
@@ -92,33 +92,31 @@ impl<G: GrantRepository, PC: PolicyControl, PS: PermissionService> GrantUseCases
         self.policy_control.reload().await
     }
 
-    /// A human grantee must belong to the organization an org/project-scoped
-    /// grant lives under. Cedar's member guard makes such a grant inert for a
-    /// non-member anyway, so persisting one would only create a row that
-    /// silently does nothing — rejecting it here keeps every stored grant
-    /// effective. System-scoped grants and machine Apps (org-owned, never
-    /// members) are exempt.
+    /// A human grantee must already belong to the scope the grant binds to: the
+    /// organization for an org-scoped grant, the project for a project-scoped
+    /// one. Cedar's membership guard makes such a grant inert for a non-member
+    /// anyway, so persisting one would only create a row that silently does
+    /// nothing — rejecting it here keeps every stored grant effective, and keeps
+    /// the write path honest about what membership means. System-scoped grants
+    /// and machine Apps (org-owned, never members) are exempt.
     async fn require_grantee_membership(&self, grant: &Grant) -> DomainResult<()> {
         let Principal::User(user_id) = &grant.principal else {
             return Ok(());
         };
-        let org_id = match &grant.scope {
-            Scope::System => return Ok(()),
-            Scope::Organization(id) => id.clone(),
-            Scope::Project(id) => self
-                .entity_provider
-                .resource_ancestors(&ResourceRef::Project(id.clone()))
-                .await?
-                .organization
-                .ok_or_else(|| DomainError::not_found("Project", id.to_string()))?,
-        };
+        if matches!(grant.scope, Scope::System) {
+            return Ok(());
+        }
         let membership = self.entity_provider.principal_authz(user_id).await?;
-        if membership.member_orgs.contains(&org_id) {
-            Ok(())
-        } else {
-            Err(DomainError::business_rule(
+        match &grant.scope {
+            Scope::System => Ok(()),
+            Scope::Organization(id) if membership.member_orgs.contains(id) => Ok(()),
+            Scope::Organization(_) => Err(DomainError::business_rule(
                 "the user must be a member of the organization before receiving a grant there",
-            ))
+            )),
+            Scope::Project(id) if membership.member_projects.contains(id) => Ok(()),
+            Scope::Project(_) => Err(DomainError::business_rule(
+                "the user must be a member of the project before receiving a grant there",
+            )),
         }
     }
 
@@ -252,7 +250,8 @@ mod tests {
     use crate::application::authz::entity_provider::{PrincipalAuthz, ResourceAncestors};
     use crate::application::authz::role::Role;
     use crate::application::caller::ServiceIdentity;
-    use crate::domain::entities::{AppId, OrganizationId, UserId};
+    use crate::domain::entities::{AppId, OrganizationId, ProjectId, UserId};
+    use crate::domain::value_objects::permission::ResourceRef;
     use async_trait::async_trait;
     use std::sync::Mutex;
 
@@ -308,13 +307,13 @@ mod tests {
 
     /// Stub membership: every user is a member of exactly `orgs`, and any
     /// project resolves under the first of them (tests use a single org).
-    struct StubMembers(Vec<OrganizationId>);
+    struct StubMembers(Vec<OrganizationId>, Vec<ProjectId>);
     #[async_trait]
     impl AuthzEntityProvider for StubMembers {
         async fn principal_authz(&self, _user: &UserId) -> DomainResult<PrincipalAuthz> {
             Ok(PrincipalAuthz {
                 member_orgs: self.0.clone(),
-                member_projects: vec![],
+                member_projects: self.1.clone(),
             })
         }
         async fn resource_ancestors(
@@ -381,9 +380,15 @@ mod tests {
         roles: Vec<Role>,
         reg: Arc<RecordingRegistry>,
     ) -> GrantUseCases<StubGrants, StubPolicy, StubPerms> {
-        // Grantees are members of o1 by default, so tests not about the
+        // Grantees are members of o1 and p1 by default, so tests not about the
         // membership rule pass it.
-        use_cases_with_members(grants, roles, reg, vec![OrganizationId::new("o1")])
+        use_cases_with_members(
+            grants,
+            roles,
+            reg,
+            vec![OrganizationId::new("o1")],
+            vec![ProjectId::new("p1")],
+        )
     }
 
     fn use_cases_with_members(
@@ -391,6 +396,7 @@ mod tests {
         roles: Vec<Role>,
         reg: Arc<RecordingRegistry>,
         member_orgs: Vec<OrganizationId>,
+        member_projects: Vec<ProjectId>,
     ) -> GrantUseCases<StubGrants, StubPolicy, StubPerms> {
         GrantUseCases::new(
             Arc::new(StubGrants(grants)),
@@ -398,7 +404,7 @@ mod tests {
             Arc::new(StubPolicy),
             Arc::new(StubPerms),
             reg,
-            Arc::new(StubMembers(member_orgs)),
+            Arc::new(StubMembers(member_orgs, member_projects)),
         )
     }
 
@@ -762,6 +768,7 @@ mod tests {
             roles.clone(),
             Arc::new(RecordingRegistry::default()),
             vec![],
+            vec![],
         );
         assert!(
             uc.grant(&service, &grant).await.is_err(),
@@ -773,6 +780,7 @@ mod tests {
             roles,
             Arc::new(RecordingRegistry::default()),
             vec![OrganizationId::new("o1")],
+            vec![],
         );
         assert!(
             uc.grant(&service, &grant).await.is_ok(),
@@ -781,9 +789,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn project_grant_requires_membership_of_the_parent_org() {
-        // A project-scoped grant resolves the project's parent org (p1 → o1 in
-        // the stub) and applies the same membership rule there.
+    async fn project_grant_requires_membership_of_the_project_itself() {
+        // Belonging to the parent organization is not enough: a project-scoped
+        // grant binds authority at the project, so the grantee must belong to
+        // that project. Otherwise Cedar's project guard would make the stored
+        // row inert.
         let roles = vec![test_role(
             PROJECT_ADMIN_ROLE,
             ScopeKind::Project,
@@ -800,11 +810,12 @@ mod tests {
             vec![],
             roles.clone(),
             Arc::new(RecordingRegistry::default()),
+            vec![OrganizationId::new("o1")],
             vec![],
         );
         assert!(
             uc.grant(&service, &grant).await.is_err(),
-            "a project grant to a user outside the parent org must be refused"
+            "org membership alone must not carry a project-scoped grant"
         );
 
         let uc = use_cases_with_members(
@@ -812,10 +823,11 @@ mod tests {
             roles,
             Arc::new(RecordingRegistry::default()),
             vec![OrganizationId::new("o1")],
+            vec![ProjectId::new("p1")],
         );
         assert!(
             uc.grant(&service, &grant).await.is_ok(),
-            "a project grant to a member of the parent org is accepted"
+            "a project grant to a member of that project is accepted"
         );
     }
 
@@ -831,6 +843,7 @@ mod tests {
             vec![],
             roles,
             Arc::new(RecordingRegistry::default()),
+            vec![],
             vec![],
         );
         let grant = Grant::new(

--- a/crates/scylla-core/src/application/project/use_case.rs
+++ b/crates/scylla-core/src/application/project/use_case.rs
@@ -286,10 +286,11 @@ impl<
             .check(caller, Permission::RemoveProjectMember(project_id.clone()))
             .await?;
 
-        // A user removed from a project may still be an org member, so their
-        // project-scoped grants must be deleted with the membership row —
-        // atomically — or they would keep authorizing. Guard the scope's last
-        // human owner before stripping anyone.
+        // Dropping the membership row is what cuts the user's authority here:
+        // every project-scoped permit is gated on live project membership. The
+        // grants go with it — atomically — so re-adding the user later starts
+        // from a clean slate instead of silently restoring their old authority.
+        // Guard the scope's last human owner before stripping anyone.
         let scope = Scope::Project(project_id.clone());
         let principal = Principal::User(user_id.clone());
         let grants = self.grant_repo.list_all().await?;
@@ -302,8 +303,8 @@ impl<
         self.project_repo
             .remove_member_and_grants(user_id, project_id)
             .await?;
-        // Deleted grant rows only stop authorizing once the policy set is
-        // rebuilt.
+        // The membership gate already denies the ex-member; deleted grant rows
+        // additionally leave the live policy set on rebuild.
         self.policy_control.reload().await
     }
 }

--- a/crates/scylla-core/src/infrastructure/services/cedar_permission_service.rs
+++ b/crates/scylla-core/src/infrastructure/services/cedar_permission_service.rs
@@ -24,23 +24,34 @@ use tracing::{info, instrument, warn};
 const SCHEMA_SRC: &str = include_str!("cedar/schema.cedarschema");
 const POLICIES_SRC: &str = include_str!("cedar/policies.cedar");
 
-/// Cedar guard appended to every org/project-scoped permit for a *human*
-/// principal: the permit only applies while the user is still a member of the
-/// organization the resource lives under. `memberOrgs` is materialised live on
-/// every check, so removing a user from an organization instantly cuts all
-/// their authority beneath it — org-scoped and project-scoped grants alike —
-/// even if a stale grant row lingers in the store. Machine Apps are owned by
-/// an org, never members of one, so they pass unguarded.
-const MEMBER_GUARD: &str =
+/// Cedar guard appended to every org-scoped permit for a *human* principal: the
+/// permit only applies while the user is still a member of the organization the
+/// resource lives under. `memberOrgs` is materialised live on every check, so
+/// removing a user from an organization instantly cuts all their authority
+/// beneath it, even if a stale grant row lingers in the store. Machine Apps are
+/// owned by an org, never members of one, so they pass unguarded.
+const ORG_MEMBER_GUARD: &str =
     "principal is Scylla::App || (principal is Scylla::User && resource in principal.memberOrgs)";
+
+/// Same, one level down: a project-scoped role only authorizes a human who
+/// belongs to that project. A grant binds authority at a scope, and membership
+/// is what makes a scope yours, so the rule is uniform with the org level rather
+/// than skipping a rung. The enclosing organization is checked too, mirroring
+/// the static `project-member` policy: leaving the org cuts project access at
+/// once even if a stale `user_project` row lingers.
+const PROJECT_MEMBER_GUARD: &str = "principal is Scylla::App \
+     || (principal is Scylla::User \
+         && resource in principal.memberProjects \
+         && resource in principal.memberOrgs)";
 
 /// The Cedar permit body for a role, instantiated per grant via the `?principal`
 /// / `?resource` slots. A full-control role (`*` permission set) gets an
 /// unconstrained action; any other role lists its permission keys explicitly.
-/// Org/project-scoped roles carry the [`MEMBER_GUARD`]; System-scoped roles
-/// (system-admin) authorize across every org without membership. Returns `None`
-/// for a role that confers nothing (empty permission set): it gets no template,
-/// so a grant of it links to nothing (and is logged as unlinkable).
+/// Org- and project-scoped roles carry the matching membership guard;
+/// System-scoped roles (system-admin) authorize across every org without
+/// membership. Returns `None` for a role that confers nothing (empty permission
+/// set): it gets no template, so a grant of it links to nothing (and is logged
+/// as unlinkable).
 fn role_template_src(role: &Role) -> Option<String> {
     let action = if role.is_full_control() {
         "action".to_string()
@@ -57,7 +68,8 @@ fn role_template_src(role: &Role) -> Option<String> {
     };
     let guard = match role.scope {
         ScopeKind::System => String::new(),
-        ScopeKind::Organization | ScopeKind::Project => format!("\nwhen {{ {MEMBER_GUARD} }}"),
+        ScopeKind::Organization => format!("\nwhen {{ {ORG_MEMBER_GUARD} }}"),
+        ScopeKind::Project => format!("\nwhen {{ {PROJECT_MEMBER_GUARD} }}"),
     };
     Some(format!(
         "permit (\n    principal == ?principal,\n    {action},\n    resource in ?resource\n){guard};\n"
@@ -734,7 +746,7 @@ mod tests {
         let svc = service(
             PrincipalAuthz {
                 member_orgs: vec![OrganizationId::new("o1")],
-                member_projects: vec![],
+                member_projects: vec![ProjectId::new("p1")],
             },
             ResourceAncestors {
                 organization: Some(OrganizationId::new("o1")),
@@ -1202,6 +1214,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn project_grant_is_inert_without_project_membership() {
+        // The mirror of the test above: same grant, same org membership, but the
+        // holder does not belong to p1. A project-scoped grant binds authority at
+        // the project, so org membership alone must not carry it. The write path
+        // refuses to create such a row; this is the runtime half of the rule.
+        let grant = Grant::new(
+            Principal::User(UserId::new("u1")),
+            role("project-admin"),
+            Scope::Project(ProjectId::new("p1")),
+        );
+        let svc = service(
+            PrincipalAuthz {
+                member_orgs: vec![OrganizationId::new("o1")],
+                member_projects: vec![],
+            },
+            ResourceAncestors {
+                organization: Some(OrganizationId::new("o1")),
+                project: Some(ProjectId::new("p1")),
+                pipeline: None,
+            },
+            vec![grant],
+        )
+        .await;
+        let caller = CallerContext::User(UserId::new("u1"));
+        assert!(
+            svc.check(&caller, Permission::DeletePipeline(PipelineId::new("pl1")))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
     async fn project_admin_cannot_escalate_to_org_grants() {
         let grant = Grant::new(
             Principal::User(UserId::new("u1")),
@@ -1211,7 +1255,7 @@ mod tests {
         let svc = service(
             PrincipalAuthz {
                 member_orgs: vec![OrganizationId::new("o1")],
-                member_projects: vec![],
+                member_projects: vec![ProjectId::new("p1")],
             },
             ResourceAncestors {
                 organization: Some(OrganizationId::new("o1")),


### PR DESCRIPTION
> Stacked on #149, itself stacked on #148. Review those first; this branch only adds the commit on top.

## The gap

A project-scoped grant only ever checked membership of the **parent organization**, in both places that matter:

- write path (`require_grantee_membership`): resolved the project's org and checked `member_orgs`;
- runtime (`MEMBER_GUARD` on every org- and project-scoped role template): `resource in principal.memberOrgs`.

So you could give `project-admin` on a project to someone who had never joined that project, and it worked: the project is inside the org, so the guard passed. Meanwhile `user_project` already conferred real authority on its own through the static `project-member` policy, and removing someone from a project already deleted their project-scoped grants. Membership was load-bearing everywhere except where the grant was created.

## The rule now

A grant at scope S requires membership at S. Same rule as the organization level, one rung down, instead of skipping a rung for no legible reason.

`MEMBER_GUARD` splits into `ORG_MEMBER_GUARD` (unchanged) and `PROJECT_MEMBER_GUARD`:

```
principal is Scylla::App
|| (principal is Scylla::User
    && resource in principal.memberProjects
    && resource in principal.memberOrgs)
```

Both conditions, mirroring the static `project-member` policy and for the reason its comment already gives: leaving the organization must cut project access at once, even if a stale `user_project` row lingers.

The write path checks `member_projects` directly, which drops a `resource_ancestors` lookup, so one query less per project grant.

## What is unaffected

- **Organization admins** keep full control of every project beneath their org: their grant is org-scoped and carries the org guard, untouched.
- **Machine apps** (agents, trigger-runner) short-circuit the guard on `principal is Scylla::App`.
- **`system-admin`** is System-scoped and carries no guard.
- **Project creation**: `provision_with_owner` writes the membership row and the owner grant in one transaction, so the creator qualifies by construction.
- No other production path creates a project-scoped grant: signup, OAuth and the trigger runner are org-scoped, bootstrap is System-scoped.

## Consequence to know about

Granting a project role becomes two steps: add the member, then grant. Step one is not a formality, it already confers the `project-member` base tier.

Any project-scoped grant currently held by a non-member goes silently inert. There is no deployed instance, but a local database could hold one; worth a quick check before merging:

```sql
SELECT g.* FROM grants g
LEFT JOIN user_project up
  ON up.user_id = g.principal_id AND up.project_id = g.scope_id
WHERE g.scope_kind = 'project' AND g.principal_kind = 'user' AND up.user_id IS NULL;
```

No frontend change: no screen creates grants yet. When one appears, its member picker should list project members rather than organization members. Adding the membership row as a side effect of granting would be the other option, and a worse one: a call that silently mutates a different aggregate.

## Tests

- `project_grant_requires_membership_of_the_project_itself`: org membership alone is refused, project membership is accepted.
- `project_grant_is_inert_without_project_membership`: the runtime half, same grant, org member but not project member, denied.
- Two existing Cedar tests now populate `member_projects`, which is the behaviour change made visible.