### PR TITLE
build(release): declare the images in docker-bake.hcl

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# Scylla — agent guide
+
+Repo-wide pointers for agents. Each area keeps its own guide next to the code;
+this file only says where to look.
+
+## Repository shape
+
+`binaries/` holds the packages that produce an executable, `crates/` the
+libraries both of them link.
+
+| Path | What it is |
+|---|---|
+| `crates/scylla-domain` | dependency-light shared kernel (domain model, `JobEvent`) |
+| `crates/scylla-proto` | the wire contract — protos under `proto/scylla/<domain>/v1/` |
+| `binaries/scylla-control-plane` | server binary: web UI, gRPC API, job dispatch, cron, webhooks |
+| `binaries/scylla-agent` | the worker installed per machine |
+| `apps/frontend` | the web UI's source; compiled into the control-plane binary |
+
+Both binary packages sit exactly two directories below the root, and that depth
+is load-bearing: `sqlx::migrate!("../../migrations")` resolves against
+`CARGO_MANIFEST_DIR`.
+
+## Guides
+
+| Topic | Where |
+|---|---|
+| **Publishing release images** | [`RELEASING.md`](./RELEASING.md) |
+| Access model (grants, roles, permissions) | [`docs/src/access-model.md`](./docs/src/access-model.md) |
+| Domain vocabulary | [`GLOSSARY.md`](./GLOSSARY.md) |
+| Running the stack | [`README.md`](./README.md) |
+| Frontend architecture and module rules | [`apps/frontend/CLAUDE.md`](./apps/frontend/CLAUDE.md) |
+| A frontend module's contract | that module's `AGENTS.md`, e.g. `apps/frontend/src/modules/features/roles/AGENTS.md` |
+
+## Conventions worth knowing before editing
+
+- **Commands live in the `justfile`, logic does not.** `just --list` is the
+  index. Recipes stay one-liners that delegate; a recipe growing an `if` or a
+  `case` is a sign the logic belongs in the tool it calls.
+- **Container builds live in `docker-bake.hcl`.** Tags included: they are
+  derived from `VERSION` and `LATEST` in the bake file, not assembled by a
+  wrapper. See [`RELEASING.md`](./RELEASING.md).
+- **The backend builds offline.** `SQLX_OFFLINE=true` against the committed
+  `.sqlx/` cache; after touching a `query!`/`query_as!` macro, run
+  `just db-prepare` and commit the result.
+- **Protos are linted and breaking-checked.** `just proto-lint`,
+  `just proto-fmt`, `just proto-breaking`.
+- **The frontend has hard CI gates** beyond typecheck and lint: architecture
+  boundaries (`pnpm depcruise`), module cycles, and i18n catalog
+  collisions. A change that passes `tsc` can still fail the build.

--- a/README.md
+++ b/README.md
@@ -152,4 +152,4 @@ just local
 ## Further reading
 
 - [Glossary](GLOSSARY.md), every Scylla-specific term, grouped by topic.
-- Releasing images: `just release` builds and pushes the multi-arch Docker images to Docker Hub. Run `just --list` for the individual recipes.
+- Releasing images: see [RELEASING.md](RELEASING.md). `just release <version>` builds and pushes the multi-arch images; `just --list` shows the individual recipes.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,238 @@
+# Releasing images
+
+Scylla ships two container images per release. This is the whole procedure:
+what gets built, where it lands, what the tags mean, and how to undo a bad
+publish.
+
+```sh
+just release-setup          # once per machine, plus `docker login`
+just release 0.4.0-beta     # build and push everything
+```
+
+## What ships, and where
+
+| Image | Built from | Contents |
+|---|---|---|
+| `scylla-control-plane` | `Dockerfile`, stage `scylla-control-plane` | the web UI, gRPC API and gRPC-Web, job dispatch, cron scheduler, webhook ingress |
+| `scylla-agent` | `Dockerfile`, stage `scylla-agent` | the worker installed per machine |
+
+Both come out of the same workspace `Dockerfile`; the bake target picks the
+final stage. Only the control plane's branch builds the web UI, so the agent
+image never pays for the Node toolchain.
+
+They publish to **Docker Hub** under the `godlyjaaaaj` account, as
+`godlyjaaaaj/<image>:<tag>`. Override with the `DOCKER_USER` environment
+variable.
+
+Each is a **multi-arch manifest** covering `linux/amd64` and `linux/arm64`, so
+`docker pull` resolves correctly on an Apple Silicon laptop and an x86 server
+alike. A single-arch publish is easy to do by accident and only fails on
+someone *else's* machine, so `just release-verify` exists to check.
+
+### The images carry no deployment-specific configuration
+
+The web UI is compiled into the control-plane binary and served from the same
+origin as the API, so the bundle addresses it with relative URLs. There is no
+API hostname baked into an artifact and therefore no per-deployment build: one
+published image works wherever it is run.
+
+## What the tags mean
+
+| Tag | Meaning |
+|---|---|
+| `0.4.0`, `0.4.0-beta` | An exact release. Immutable — never republish over one. |
+| `latest` | What `just up` pulls. Moves to each new release unless you opt out. |
+| `beta` | Optional moving channel for pre-releases. |
+
+Image tags drop the `v` that git tags carry: git `v0.4.0-beta` publishes images
+tagged `0.4.0-beta`.
+
+**`latest` moves with every release by default.** Scylla is pre-1.0 and every
+release so far has been a beta — `latest` has pointed at the newest beta since
+0.1.0 — so gating the channel on a stable/pre-release distinction the project
+does not have yet would simply freeze it.
+
+Opt out with `LATEST=false` when publishing something that must not become the
+default pull:
+
+```sh
+LATEST=false just release 0.3.1     # republish an older line, leave latest alone
+```
+
+Rolling `latest` back to an earlier version is a retag, not a build. See below.
+
+## Before the first release on a machine
+
+```sh
+docker login -u godlyjaaaaj    # once; credentials are cached
+just release-setup             # creates the `scylla-builder` buildx builder
+```
+
+`release-setup` is idempotent and `just release` runs it for you. `docker
+login` is the one step nothing can do on your behalf; without it the build runs
+to completion and then fails at the push.
+
+## Releasing
+
+**Before you start**, confirm these yourself — the recipes are deliberately
+thin and check none of them:
+
+- [ ] everything is landed on `main`, and `git status` is clean — the images
+      record an `org.opencontainers.image.revision` label, which otherwise
+      points at a commit that does not describe them
+- [ ] `.sqlx/` is present and current (`just db-prepare`) — the backend builds
+      with `SQLX_OFFLINE=true` and dies deep inside the Rust compile without it
+- [ ] you are logged in to Docker Hub
+
+Then:
+
+1. **Tag and push the tag:**
+
+   ```sh
+   git tag -a v0.4.0-beta -m "Scylla v0.4.0-beta"
+   git push origin refs/tags/v0.4.0-beta
+   ```
+
+   Push with the full `refs/tags/` path. A bare `git push origin v0.4.0-beta`
+   is ambiguous whenever a branch shares the name, and git refuses with
+   `src refspec … matches more than one`.
+
+2. **Check the plan, then publish:**
+
+   ```sh
+   just release-plan 0.4.0-beta    # resolved tags and args, builds nothing
+   just release 0.4.0-beta
+   ```
+
+   Read the plan's tags before building: they are the whole `latest` decision.
+
+3. **Verify, then write the GitHub release** against the tag, in the shape of
+   the previous ones: a short intro, `## Highlights`, `## Breaking changes`
+   when there are any, `## What's in this release`, `## Quick start`,
+   `## Feedback`, then the generated `## What's Changed`. Mark pre-releases as
+   such.
+
+### How long it takes
+
+On a laptop the non-native architecture builds under QEMU emulation, which is
+slow: budget **45 to 90 minutes** for a full release on Apple Silicon. The web
+UI is pinned to the builder's architecture and takes about two minutes.
+
+Both images build in **one** `docker buildx bake` invocation, concurrently
+against a single BuildKit session. That is the point of the bake file: the
+control plane and the agent share their entire `cargo chef` dependency layer,
+so baking them together cooks it once instead of twice.
+
+To build a single image without paying for the others, call bake directly:
+
+```sh
+VERSION=0.4.0-beta docker buildx bake -f docker-bake.hcl --push control-plane
+VERSION=0.4.0-beta docker buildx bake -f docker-bake.hcl --push agent
+```
+
+## Verifying
+
+```sh
+just release-verify 0.4.0-beta
+```
+
+It prints each published manifest. Check that every entry lists both
+`linux/amd64` and `linux/arm64`; an `unknown/unknown` line is the attestation
+manifest and is expected.
+
+## Moving a channel, and rolling back
+
+`release-promote` repoints a channel tag at an already-published version. It
+copies the manifest list rather than rebuilding, so it is instant and keeps
+every architecture:
+
+```sh
+just release-promote 0.4.0-beta beta    # newest beta, for testers
+just release-promote 0.4.0 latest       # a bad 0.5.0 shipped — go back
+```
+
+Rolling back *is* this: point `latest` at the previous good version. Never
+delete or overwrite a version tag — someone is pinning it, and a mutated
+version tag makes "works on my machine" unfalsifiable.
+
+It takes the channel name explicitly and asks no questions, so it also serves
+any channel the bake file does not manage — `beta`, `edge`, a customer pin.
+
+## Command reference
+
+| Command | Does |
+|---|---|
+| `just release-setup` | create the buildx builder (idempotent) |
+| `just release-plan <version>` | print the resolved plan, build nothing |
+| `just release <version>` | build and push both images |
+| `just release-verify <version>` | print the published manifests |
+| `just release-promote <version> <tag>` | move a channel tag, no rebuild |
+
+Environment: `DOCKER_USER`, `BUILDER` (top of the `justfile`), plus the bake
+variables below — most usefully `LATEST=false`. Platforms live in the bake
+file's `PLATFORMS`, not the justfile.
+
+## How the build is defined
+
+`docker-bake.hcl` holds the build itself — targets, platforms, tags, labels,
+build args and cache — and the `just` recipes are one-line pass-throughs to it.
+Anything about *how* an image is built belongs in the bake file, not the
+justfile.
+
+Its variables: `VERSION`, `LATEST`, `DOCKER_USER`, `PLATFORMS`, `GIT_SHA`,
+`CACHE`. Targets: `control-plane`, `agent`. One group, `release`, holding both.
+
+Driving bake directly is fine, but **always pass `-f docker-bake.hcl`**:
+
+```sh
+docker buildx bake -f docker-bake.hcl --print release
+```
+
+Without `-f`, bake also loads `docker-compose.yaml` and turns its services into
+extra targets named after them — single-arch, untagged, and easy to build by
+mistake.
+
+### Shared build cache
+
+`CACHE` is empty by default, so builds rely on the local builder's cache. Point
+it at a registry ref to share layers between machines:
+
+```sh
+CACHE=godlyjaaaaj/scylla-buildcache just release 0.4.0
+```
+
+The control plane and the agent deliberately share one cache ref: they have
+every layer in common up to `cargo build -p`, and that is what makes the second
+image nearly free.
+
+## Troubleshooting
+
+**`denied: requested access to the resource is denied`.** Not logged in, or
+`DOCKER_USER` is not your account. Run `docker login -u godlyjaaaaj`.
+
+**The Rust build fails on a `query!` macro.** `.sqlx/` is stale or missing. Run
+`just db-prepare` and commit the result.
+
+**The build is slow.** That is emulation, not a bug. Building
+`PLATFORMS=linux/arm64` alone on Apple Silicon is fast, but the result is
+**not** a release: it leaves x86 users with nothing to pull.
+
+**`docker buildx bake` builds the wrong thing.** You forgot `-f
+docker-bake.hcl` and got a compose service.
+
+## Design notes
+
+The release used to be a loop of `docker buildx build` calls in the justfile,
+documented by one line in the README, with two sharp edges: `VERSION` defaulted
+to `latest`, so a bare `just release` tagged the images `latest` twice and
+published no version at all; and every release moved `latest`, betas included.
+
+Moving the build into `docker-bake.hcl` fixed both by construction, and bought
+the concurrency and the shared dependency layer along the way. The `latest`
+rule is derived from the version inside the bake file rather than guarded by a
+wrapper, which is why the justfile has no validation code in it — the same rule
+`docker/metadata-action` calls `latest=auto`, and the same file CI would use
+through `docker/bake-action` if this ever moves off a laptop.
+
+The trade is deliberate: nothing stops you releasing from a dirty tree or
+without `.sqlx/`. Those are the checklist above, not code.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,122 @@
+# Release image definitions for `docker buildx bake`.
+#
+# Both published images in one declarative file. Bake builds every target of a
+# group concurrently against a single BuildKit session, which is why this
+# replaced a loop of `docker buildx build` calls: `control-plane` and `agent`
+# share the whole cargo-chef dependency layer, and building them in one bake
+# cooks it once instead of twice.
+#
+# Always pass `-f docker-bake.hcl`: without it bake also loads
+# docker-compose.yaml and turns its services into extra, single-arch targets.
+#
+#   VERSION=0.4.0 docker buildx bake -f docker-bake.hcl --print release
+#   VERSION=0.4.0 docker buildx bake -f docker-bake.hcl --push release
+#
+# `just release <version>` is the wrapper; the process is in RELEASING.md.
+
+variable "VERSION" {
+  default     = ""
+  description = "Release version, e.g. 0.4.0-beta. Required: an empty value tags nothing."
+}
+
+variable "DOCKER_USER" {
+  default     = "godlyjaaaaj"
+  description = "Registry account the images are published under."
+}
+
+variable "PLATFORMS" {
+  default     = "linux/amd64,linux/arm64"
+  description = "Comma-separated platforms for the multi-arch manifest."
+}
+
+variable "GIT_SHA" {
+  default     = ""
+  description = "Commit the images were built from, recorded as an OCI label."
+}
+
+variable "LATEST" {
+  default     = "true"
+  description = "Also tag `latest`. Set false when publishing something that must not become the default pull — a re-release of an older version, or a build nobody should get by accident."
+}
+
+variable "CACHE" {
+  default     = ""
+  description = "Registry ref prefix for a shared build cache, e.g. godlyjaaaaj/scylla-buildcache. Empty disables it and relies on the local builder cache."
+}
+
+# The version tag always; `latest` unless told otherwise.
+#
+# Scylla is pre-1.0 and every release so far has been a beta — `latest` has
+# pointed at the newest beta since 0.1.0. Gating the channel on a stable/
+# pre-release distinction the project does not have yet would freeze `latest`
+# on 0.3.0 indefinitely, so the default is to move it.
+#
+# Opt out with LATEST=false when republishing an older version, where moving
+# the channel would walk `just up` backwards.
+function "tags" {
+  params = [image]
+  result = concat(
+    VERSION != "" ? ["${DOCKER_USER}/${image}:${VERSION}"] : [],
+    VERSION != "" && LATEST == "true" ? ["${DOCKER_USER}/${image}:latest"] : [],
+  )
+}
+
+# One cache ref per entry, so a target's layers never collide with an unrelated
+# one's. Both images point at the same backend ref on purpose — see `agent`.
+function "cache_from" {
+  params = [image]
+  result = CACHE != "" ? [{ type = "registry", ref = "${CACHE}:${image}" }] : []
+}
+
+function "cache_to" {
+  params = [image]
+  result = CACHE != "" ? [{ type = "registry", ref = "${CACHE}:${image}", mode = "max" }] : []
+}
+
+target "_common" {
+  context   = "."
+  platforms = split(",", PLATFORMS)
+
+  labels = {
+    "org.opencontainers.image.source"   = "https://github.com/scylla-ops/scylla"
+    "org.opencontainers.image.version"  = VERSION
+    "org.opencontainers.image.revision" = GIT_SHA
+  }
+}
+
+# Both binaries build from the workspace Dockerfile, which ends in one final
+# stage per package; `target` picks the stage. Everything below it — the cooked
+# dependency layer and the shared source layer — is identical for the two, so
+# bake reuses it across both targets in a single run.
+target "_backend" {
+  inherits   = ["_common"]
+  dockerfile = "Dockerfile"
+}
+
+target "control-plane" {
+  inherits   = ["_backend"]
+  target     = "scylla-control-plane"
+  tags       = tags("scylla-control-plane")
+  cache-from = cache_from("scylla-backend")
+  cache-to   = cache_to("scylla-backend")
+}
+
+target "agent" {
+  inherits   = ["_backend"]
+  target     = "scylla-agent"
+  tags       = tags("scylla-agent")
+  # Same cache ref as the control plane on purpose: they share every layer up
+  # to their own `cargo build -p`, and pointing both at one ref is what makes
+  # the second image nearly free. The control plane's `ui` stage is extra
+  # layers on that shared ref, not a competing one.
+  cache-from = cache_from("scylla-backend")
+  cache-to   = cache_to("scylla-backend")
+}
+
+group "release" {
+  targets = ["control-plane", "agent"]
+}
+
+group "default" {
+  targets = ["release"]
+}

--- a/justfile
+++ b/justfile
@@ -7,8 +7,6 @@ VERSION      := env("VERSION", "latest")
 DATABASE_URL := env("DATABASE_URL", "postgres://scylla:scylla@localhost:5432/scylla")
 BUILDER      := env("BUILDER", "scylla-builder")
 
-platforms := "linux/amd64,linux/arm64"
-
 # -- Aliases --
 alias u := up
 alias s := start
@@ -108,46 +106,39 @@ db-reset:
     docker volume rm scylla_postgres_data || true
     docker compose up -d postgres
 
-# -- Release (manual multi-arch build & push to Docker Hub) --
+# -- Release (multi-arch build & push to Docker Hub) --
 #
-# Plain buildx: the same Dockerfiles as local dev, built for amd64 + arm64 and
-# pushed with their multi-arch manifest. The non-native platform builds under
-# emulation, so a full release is slow — but it is one command, reproducible
-# anywhere Docker runs, and needs no host toolchain.
-#
-#   just release-setup            # once per machine (+ docker login)
-#   VERSION=0.3.0 just release    # full stack: control-plane + agent + frontend
+# The build is declared in docker-bake.hcl; `latest` follows stable versions
+# automatically. Full process, checklist and rollback: RELEASING.md
 
 # One-time: create the multi-arch buildx builder
 [group('release')]
 release-setup:
     docker buildx inspect {{BUILDER}} >/dev/null 2>&1 || docker buildx create --name {{BUILDER}} --driver docker-container --bootstrap
-    @echo "✓ buildx builder '{{BUILDER}}' ready (remember: docker login)"
 
-# Build & push everything. The web UI ships inside the control-plane image.
+# Print the resolved release plan without building anything
 [group('release')]
 [no-exit-message]
-release: (release-svc "scylla-control-plane") (release-svc "scylla-agent")
+release-plan version:
+    VERSION={{version}} docker buildx bake -f docker-bake.hcl --print release
 
-# Build & push the backend services (control-plane + agent)
+# Build & push every release image (e.g. just release 0.4.0-beta)
 [group('release')]
 [no-exit-message]
-release-backend: (release-svc "scylla-control-plane") (release-svc "scylla-agent")
+release version: release-setup
+    VERSION={{version}} GIT_SHA=`git rev-parse HEAD` docker buildx bake -f docker-bake.hcl --builder {{BUILDER}} --push release
 
-# Build & push one backend service (e.g. just release-svc scylla-agent)
+# Show the published manifests, to confirm every platform is there
 [group('release')]
 [no-exit-message]
-release-svc pkg: _info
-    docker buildx build --builder {{BUILDER}} --platform {{platforms}} \
-        --target {{pkg}} \
-        -t {{DOCKER_USER}}/{{pkg}}:{{VERSION}} \
-        -t {{DOCKER_USER}}/{{pkg}}:latest \
-        --push .
+release-verify version:
+    for image in scylla-control-plane scylla-agent; do docker buildx imagetools inspect {{DOCKER_USER}}/$image:{{version}}; done
 
-[private]
+# Point a channel tag at a published version, without rebuilding
+[group('release')]
 [no-exit-message]
-_info:
-    @echo "══ user={{DOCKER_USER}} version={{VERSION}} platforms={{platforms}} ══"
+release-promote version tag:
+    for image in scylla-control-plane scylla-agent; do docker buildx imagetools create --tag {{DOCKER_USER}}/$image:{{tag}} {{DOCKER_USER}}/$image:{{version}}; done
 
 # -- Protos --
 


### PR DESCRIPTION
> **Stacked on #161.** Based on `feat/single-binary-unified-server` so the diff
> shows only the release work; GitHub retargets it to `v0.4.1` when #161 merges.
> Review #161 first.

The release was a loop of `docker buildx build` calls in the justfile,
documented by one line in the README. It carried two sharp edges:

- `VERSION` defaulted to `latest`, so a bare `just release` tagged the images
  `latest` twice and published no version at all — silently.
- Every release moved `latest`, with no way to opt out.

`docker-bake.hcl` now holds the build — targets, platforms, tags, labels, args
and cache — and the `just` recipes are one-line pass-throughs. Tagging is
derived from `VERSION` and `LATEST` inside the bake file rather than assembled
by a wrapper, so the justfile carries no logic.

Baking both images in one BuildKit session also cooks the shared cargo-chef
dependency layer once instead of twice: the control plane and the agent have
every layer in common up to `cargo build -p`.

`RELEASING.md` documents the process end to end — tag conventions,
prerequisites, the pre-flight checklist, verification, and rollback by
retagging. `AGENTS.md` points at it and at the other per-area guides.

## What the rebase changed

This branch predates the unified binary, which reshapes what there is to
release. Adapted rather than merged as-is:

| Before | Now |
|---|---|
| `target "frontend"` → `apps/frontend/Dockerfile` | gone — the bundle ships inside the control-plane image |
| `args = { PACKAGE = "…" }` | `target = "scylla-control-plane"` / `"scylla-agent"` |
| `VITE_API_URL` variable | gone — the bundle addresses its own origin, so no artifact is pinned to a hostname |
| `group "release"` (3) + `group "backend"` (2) | one `group "release"`, both images |
| `platforms` in the justfile | dead once bake owns `PLATFORMS`; removed |

`RELEASING.md` and `AGENTS.md` follow: two images, stage-per-package, and the
new `binaries/` + `crates/` layout with a note that the two-level depth is
load-bearing for `sqlx::migrate!("../../migrations")`.

**The branch's second commit is dropped, not carried.** It pinned the
frontend's Node stage to `$BUILDPLATFORM` in a Dockerfile that no longer
exists — and the unified Dockerfile already pins its `ui` stage the same way,
for the same reason (esbuild is a Go binary and dies under QEMU on the
non-native leg).

## Verified

```
$ VERSION=0.4.1-test docker buildx bake -f docker-bake.hcl --print release
groupe release -> ['control-plane', 'agent']
  agent:         stage=scylla-agent         dockerfile=Dockerfile
  control-plane: stage=scylla-control-plane dockerfile=Dockerfile
```

Tags resolve to `<user>/<image>:0.4.1-test` plus `latest`. `just --list` shows
the five release recipes. No stale reference to `scylla-frontend`,
`VITE_API_URL` or `PACKAGE=` survives outside the README's migration warning,
which deliberately tells users to clean up the orphaned container.

Not exercised: an actual `--push` release.